### PR TITLE
fix: get pin slot from the correct byte

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -508,10 +508,10 @@ class Lock:
             return LockActivity(timestamp, lock_status)
         if activity_type == LockActivityType.PIN.value:
             # Timestamp is at 0x05-0x08
-            # Slot is at 0x10
+            # Slot is at 0x0A
             # Lock status seems to be at lower half of 0x0C
             timestamp = self._parse_unix_timestamp(response[0x05:0x09])
-            pin_slot = response[0x10]
+            pin_slot = response[0x0A]
             lock_status = self._parse_lock_status(response[0x0C] & 0x0F)
 
             return LockActivity(timestamp, lock_status, pin_slot)


### PR DESCRIPTION
Changed to the correct byte based on [the conversation][gh-convo] with @Sobuno.

[gh-convo]: https://github.com/Yale-Libs/yalexs-ble/pull/208#discussion_r2311650568