### PR TITLE
fix!: auto-lock relock parameter is actually two 16-bit timers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ exclude_lines = [
 profile = "black"
 known_first_party = ["yalexs_ble", "tests"]
 
+[tool.codespell]
+ignore-words-list = "yur"
+
 [tool.mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -132,13 +132,13 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 
 
 class AutoLockMode(IntEnum):
+    # Derived from the setting's stored value, NOT read from a wire byte -- the
+    # auto-lock response carries no mode byte (see Lock._parse_auto_lock_state).
+    # The int values are retained only as the mode marker the write path emits.
     INSTANT = 0x00
     TIMER = 0x5A
     # Not a valid value from the lock, but used to signal that auto lock is disabled
     OFF = 0xFF
-
-
-VALUE_TO_AUTO_LOCK_MODE = {status.value: status for status in AutoLockMode}
 
 
 class LockActivityType(Enum):

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -132,9 +132,11 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 
 
 class AutoLockMode(IntEnum):
-    # Derived from the setting's stored value, NOT read from a wire byte -- the
-    # auto-lock response carries no mode byte (see Lock._parse_auto_lock_state).
-    # The int values are retained only as the mode marker the write path emits.
+    # The int values are the wire constants from the old single-value encoding,
+    # kept so the public enum values stay stable. The mode is no longer read
+    # from or written to a wire byte: it is derived from the stored value's
+    # shape on read (see Lock._parse_auto_lock_state) and implied by that shape
+    # on write (see Lock.set_auto_lock), which emits no mode byte.
     INSTANT = 0x00
     TIMER = 0x5A
     # Not a valid value from the lock, but used to signal that auto lock is disabled

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -132,15 +132,12 @@ VALUE_TO_DOOR_STATUS = {status.value: status for status in DoorStatus}
 
 
 class AutoLockMode(IntEnum):
-    # The int values are the wire constants from the old single-value encoding,
-    # kept so the public enum values stay stable. The mode is no longer read
-    # from or written to a wire byte: it is derived from the stored value's
-    # shape on read (see Lock._parse_auto_lock_state) and implied by that shape
-    # on write (see Lock.set_auto_lock), which emits no mode byte.
-    INSTANT = 0x00
-    TIMER = 0x5A
-    # Not a valid value from the lock, but used to signal that auto lock is disabled
-    OFF = 0xFF
+    # The values are arbitrary; the mode never crosses the wire. It is derived
+    # from the stored value's shape on read (see Lock._parse_auto_lock_state)
+    # and implied by that shape on write (see Lock.set_auto_lock).
+    INSTANT = 0
+    TIMER = 1
+    OFF = 2
 
 
 class LockActivityType(Enum):

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -416,20 +416,33 @@ class Lock:
 
     @raise_if_not_connected
     async def set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:
-        """Change the auto lock setting."""
+        """Change the auto lock setting (0x28).
+
+        The value is a single little-endian uint32 at [8:12], mirroring the
+        read side: 0 = off, ``n`` (low half only) = instant with an ``n``
+        second delay, ``N | (N << 16)`` = timed relock after ``N`` seconds
+        (the decoder reads the high half; the low copy is a write convention).
+        There is no mode byte -- the mode is implied by the value shape.
+        """
         _LOGGER.debug(
             "%s: Setting auto lock to mode=%d, dur=%d", self.name, mode, duration
         )
         assert self.session is not None  # nosec
-        if mode == AutoLockMode.OFF:
-            mode = AutoLockMode.INSTANT
-            duration = 0
+        if mode == AutoLockMode.OFF or duration == 0:
+            value = 0
+        elif not 1 <= duration <= 0xFFFE:
+            # The seconds live in a 16-bit half; cap conservatively below
+            # the field maximum.
+            raise ValueError(f"Auto lock duration out of range (1-65534): {duration}")
+        elif mode == AutoLockMode.TIMER:
+            value = duration | (duration << 16)
+        else:  # INSTANT
+            value = duration
 
         cmd = self.session.build_operation_command(
             Commands.WRITESETTING, SettingType.AUTOLOCK
         )
-        util._copy(cmd, util._int_to_bytes(duration, 2), destLocation=0x08)
-        cmd[0x0A] = mode
+        util._copy(cmd, util._int_to_bytes(value, 4), destLocation=0x08)
         await self.session.execute(cmd, "set_auto_lock")
         _LOGGER.debug("%s: Finished setting auto lock", self.name)
 

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -444,13 +444,13 @@ class Lock:
     async def set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:
         """Change the auto lock setting (0x28).
 
-        The value is a little-endian uint32 at [8:12] holding two 16-bit
-        timers: the never-opened timer at [8:10] and the door-close timer at
-        [10:12]. 0 = off; ``n`` in the never-opened half alone = instant with
-        an ``n`` second delay; ``N | (N << 16)`` = timed relock after ``N``
-        seconds, with both timers set to the same value. There is no mode
-        byte -- the mode is implied by the value shape, and the read side
-        reports the never-opened half (see ``_parse_auto_lock_state``).
+        The value is two little-endian uint16 timers laid consecutively at
+        [8:12]: the never-opened timer at [8:10] and the door-close timer at
+        [10:12]. Both zero = off; ``n`` in the never-opened timer alone =
+        instant with an ``n`` second delay; a timed relock sets both timers to
+        the same ``n`` seconds. There is no mode byte -- the mode is implied by
+        which timers are set, and the read side reports the never-opened timer
+        (see ``_parse_auto_lock_state``).
         """
         _LOGGER.debug(
             "%s: Setting auto lock to mode=%d, dur=%d", self.name, mode, duration
@@ -459,8 +459,8 @@ class Lock:
         if mode == AutoLockMode.OFF or duration == 0:
             value = 0
         elif not 1 <= duration <= 0xFFFE:
-            # The seconds live in a 16-bit half; cap conservatively below
-            # the field maximum.
+            # Each timer is a uint16; cap conservatively below the field
+            # maximum.
             raise ValueError(f"Auto lock duration out of range (1-65534): {duration}")
         elif mode == AutoLockMode.TIMER:
             value = duration | (duration << 16)
@@ -533,19 +533,18 @@ class Lock:
     def _parse_auto_lock_state(self, response: bytes) -> AutoLockState:
         """Parse the auto lock state from a READSETTING (setting 0x28) response.
 
-        The auto-lock time is a single little-endian uint32 at
-        ``response[8:12]``; there is no mode byte. It packs two 16-bit timers:
-        the low half (bytes [8:10]) is the never-opened timer and the high half
-        (bytes [10:12]) is the door-close timer. A Timed relock is encoded by
-        the lock as ``seconds | (seconds << 16)`` -- the same seconds in both
-        halves -- so a non-zero high half signals Timed. A value with only the
-        low half set is Instant; zero is off. The mode is derived from the
-        value, never read from a wire byte.
+        The auto-lock time is two little-endian uint16 timers laid
+        consecutively at ``response[8:12]``; there is no mode byte. The
+        never-opened timer is at [8:10] and the door-close timer at [10:12]. A
+        Timed relock sets both timers to the same seconds, so a non-zero
+        door-close timer signals Timed. A value with only the never-opened
+        timer set is Instant; both zero is off. The mode is derived from which
+        timers are set, never read from a wire byte.
 
-        The Timed decode reports the never-opened half: it is the field the
+        The Timed decode reports the never-opened timer: it is the field the
         app displays, and releases before the two-timer encoding stored the
         user's seconds there, so those values read back as set. A zero
-        never-opened half falls back to the door-close half. A write derived
+        never-opened timer falls back to the door-close timer. A write derived
         from this state sets both timers to the same value.
         """
         value = util._bytes_to_int(response[0x08:0x0C])

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -532,11 +532,17 @@ class Lock:
         """Parse the auto lock state from a READSETTING (setting 0x28) response.
 
         The auto-lock time is a single little-endian uint32 at
-        ``response[8:12]``; there is no mode byte. A Timed relock is
-        encoded by the lock as ``seconds | (seconds << 16)`` -- the same seconds
-        in both 16-bit halves -- so a non-zero high half signals Timed and
-        carries the seconds. A value with only the low half set is Instant; zero
-        is off. The mode is derived from the value, never read from a wire byte.
+        ``response[8:12]``; there is no mode byte. It packs two 16-bit timers:
+        the low half (bytes [8:10]) is the never-opened timer and the high half
+        (bytes [10:12]) is the door-close timer. A Timed relock is encoded by
+        the lock as ``seconds | (seconds << 16)`` -- the same seconds in both
+        halves -- so a non-zero high half signals Timed and carries the seconds.
+        A value with only the low half set is Instant; zero is off. The mode is
+        derived from the value, never read from a wire byte.
+
+        The Timed decode keeps the door-close half and drops the never-opened
+        half, so a write derived from this state sets both timers to the same
+        value.
         """
         value = util._bytes_to_int(response[0x08:0x0C])
         if value == 0:
@@ -586,21 +592,23 @@ class Lock:
         return self._parse_battery_state(response)
 
     @raise_if_not_connected
-    async def auto_lock_status(self) -> AutoLockState:
+    async def auto_lock_status(self) -> None:
+        """Request the auto-lock setting.
+
+        The wait completes on the READSETTING acknowledgment, whose value field
+        is zero, so it carries no setting; there is nothing to return. The
+        stored setting arrives moments later as a 0xBB settings response on the
+        notify path, which the push layer decodes and applies. Waiting for that
+        settings response instead would stall the poll for the full write
+        timeout on a lock that never answers READSETTING (no auto-lock support).
+        """
         _LOGGER.debug("%s: Executing auto_lock_status", self.name)
-        # Deliberately untyped wait: it completes on the READSETTING
-        # acknowledgment, whose value field is zero, so the return value is
-        # not the stored setting. The 0xBB settings response arrives moments
-        # later on the notify path and the push layer applies it from there.
-        # A typed wait would stall the poll for the full write timeout on a
-        # lock that never answers READSETTING (no auto-lock support).
-        response = await self._execute_command(
+        await self._execute_command(
             Commands.READSETTING,
             SettingType.AUTOLOCK,
             "auto_lock_status",
         )
         _LOGGER.debug("%s: Finished executing auto_lock_status", self.name)
-        return self._parse_auto_lock_state(response)
 
     def _parse_unix_timestamp(self, timestamp_bytes: bytes) -> datetime:
         """Parse the unix timestamp to datetime from the bytes."""

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -444,11 +444,13 @@ class Lock:
     async def set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:
         """Change the auto lock setting (0x28).
 
-        The value is a single little-endian uint32 at [8:12], mirroring the
-        read side: 0 = off, ``n`` (low half only) = instant with an ``n``
-        second delay, ``N | (N << 16)`` = timed relock after ``N`` seconds
-        (the decoder reads the high half; the low copy is a write convention).
-        There is no mode byte -- the mode is implied by the value shape.
+        The value is a little-endian uint32 at [8:12] holding two 16-bit
+        timers: the never-opened timer at [8:10] and the door-close timer at
+        [10:12]. 0 = off; ``n`` in the never-opened half alone = instant with
+        an ``n`` second delay; ``N | (N << 16)`` = timed relock after ``N``
+        seconds, with both timers set to the same value. There is no mode
+        byte -- the mode is implied by the value shape, and the read side
+        reports the never-opened half (see ``_parse_auto_lock_state``).
         """
         _LOGGER.debug(
             "%s: Setting auto lock to mode=%d, dur=%d", self.name, mode, duration
@@ -536,20 +538,24 @@ class Lock:
         the low half (bytes [8:10]) is the never-opened timer and the high half
         (bytes [10:12]) is the door-close timer. A Timed relock is encoded by
         the lock as ``seconds | (seconds << 16)`` -- the same seconds in both
-        halves -- so a non-zero high half signals Timed and carries the seconds.
-        A value with only the low half set is Instant; zero is off. The mode is
-        derived from the value, never read from a wire byte.
+        halves -- so a non-zero high half signals Timed. A value with only the
+        low half set is Instant; zero is off. The mode is derived from the
+        value, never read from a wire byte.
 
-        The Timed decode keeps the door-close half and drops the never-opened
-        half, so a write derived from this state sets both timers to the same
-        value.
+        The Timed decode reports the never-opened half: it is the field the
+        app displays, and releases before the two-timer encoding stored the
+        user's seconds there, so those values read back as set. A zero
+        never-opened half falls back to the door-close half. A write derived
+        from this state sets both timers to the same value.
         """
         value = util._bytes_to_int(response[0x08:0x0C])
         if value == 0:
             return AutoLockState(AutoLockMode.OFF, 0)
-        if seconds := (value >> 16) & 0xFFFF:
-            return AutoLockState(AutoLockMode.TIMER, seconds)
-        return AutoLockState(AutoLockMode.INSTANT, value & 0xFFFF)
+        never_opened = value & 0xFFFF
+        door_close = (value >> 16) & 0xFFFF
+        if door_close:
+            return AutoLockState(AutoLockMode.TIMER, never_opened or door_close)
+        return AutoLockState(AutoLockMode.INSTANT, never_opened)
 
     @raise_if_not_connected
     async def lock_status(self) -> LockStatus:

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -107,6 +107,29 @@ def convert_voltage_to_percentage(voltage: float) -> int:
     return AA_BATTERY_VOLTAGE_MAP[AA_BATTERY_VOLTAGE_LIST[pos]]
 
 
+def _settings_response_matcher(
+    command_value: int, setting_value: int
+) -> Callable[[bytes], bool]:
+    """Match the 0xBB settings frame answering one command/setting pair.
+
+    A settings command (READSETTING/WRITESETTING) is answered by two frames:
+    an 0xAA acknowledgment echoing the request, then the 0xBB frame carrying
+    the stored value. The acknowledgment's value field is zero, so completing
+    the solicited wait on it misreads every setting; the wait must hold out
+    for the 0xBB frame that echoes the command opcode and the setting id.
+    """
+
+    def matches(data: bytes) -> bool:
+        return (
+            len(data) >= 0x0C
+            and data[0x00] == 0xBB
+            and data[0x01] == command_value
+            and data[0x04] == setting_value
+        )
+
+    return matches
+
+
 class Lock:
     def __init__(
         self,
@@ -266,13 +289,16 @@ class Lock:
                 return [LockStatus.UNLOCKED]
             if state[1] == Commands.LOCK.value:
                 return [LockStatus.LOCKED]
-            if state[1] == Commands.READSETTING.value:
-                # ACK for a settings read (for example auto-lock, setting 0x28). It
-                # carries no state -- the value arrives in the BB 04 settings
-                # response -- so
+            if state[1] in (
+                Commands.READSETTING.value,
+                Commands.WRITESETTING.value,
+            ):
+                # ACK for a settings command (for example auto-lock, setting
+                # 0x28). It carries no state -- the value arrives in the 0xBB
+                # settings response -- so
                 # recognize and ignore it rather than logging "Unknown state".
-                # Kept specific to READSETTING so a new ACK type on another
-                # model still surfaces as an unknown frame.
+                # Kept specific to the settings opcodes so a new ACK type on
+                # another model still surfaces as an unknown frame.
                 return ()
         return None
 
@@ -443,7 +469,13 @@ class Lock:
             Commands.WRITESETTING, SettingType.AUTOLOCK
         )
         util._copy(cmd, util._int_to_bytes(value, 4), destLocation=0x08)
-        await self.session.execute(cmd, "set_auto_lock")
+        await self.session.execute(
+            cmd,
+            "set_auto_lock",
+            _settings_response_matcher(
+                Commands.WRITESETTING.value, SettingType.AUTOLOCK.value
+            ),
+        )
         _LOGGER.debug("%s: Finished setting auto lock", self.name)
 
     async def securemode(self) -> None:
@@ -556,8 +588,16 @@ class Lock:
     @raise_if_not_connected
     async def auto_lock_status(self) -> AutoLockState:
         _LOGGER.debug("%s: Executing auto_lock_status", self.name)
+        # Deliberately untyped wait: it completes on the READSETTING
+        # acknowledgment, whose value field is zero, so the return value is
+        # not the stored setting. The 0xBB settings response arrives moments
+        # later on the notify path and the push layer applies it from there.
+        # A typed wait would stall the poll for the full write timeout on a
+        # lock that never answers READSETTING (no auto-lock support).
         response = await self._execute_command(
-            Commands.READSETTING, SettingType.AUTOLOCK, "auto_lock_status"
+            Commands.READSETTING,
+            SettingType.AUTOLOCK,
+            "auto_lock_status",
         )
         _LOGGER.debug("%s: Finished executing auto_lock_status", self.name)
         return self._parse_auto_lock_state(response)

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -21,7 +21,6 @@ from .const import (
     FIRMWARE_REVISION_CHARACTERISTIC,
     MODEL_NUMBER_CHARACTERISTIC,
     SERIAL_NUMBER_CHARACTERISTIC,
-    VALUE_TO_AUTO_LOCK_MODE,
     VALUE_TO_DOOR_STATUS,
     VALUE_TO_LOCK_OPERATION_REMOTE_TYPE,
     VALUE_TO_LOCK_OPERATION_SOURCE,
@@ -267,6 +266,14 @@ class Lock:
                 return [LockStatus.UNLOCKED]
             if state[1] == Commands.LOCK.value:
                 return [LockStatus.LOCKED]
+            if state[1] == Commands.READSETTING.value:
+                # ACK for a settings read (for example auto-lock, setting 0x28). It
+                # carries no state -- the value arrives in the BB 04 settings
+                # response -- so
+                # recognize and ignore it rather than logging "Unknown state".
+                # Kept specific to READSETTING so a new ACK type on another
+                # model still surfaces as an unknown frame.
+                return ()
         return None
 
     def _internal_state_callback(self, state: bytes) -> None:
@@ -477,18 +484,21 @@ class Lock:
         return door_status_enum
 
     def _parse_auto_lock_state(self, response: bytes) -> AutoLockState:
-        """Parse the auto lock state from the response."""
-        duration = util._bytes_to_int(response[0x08:0x0A])
-        raw_mode = response[0x0A]
-        mode = VALUE_TO_AUTO_LOCK_MODE.get(raw_mode, AutoLockMode.OFF)
-        if raw_mode not in VALUE_TO_AUTO_LOCK_MODE:
-            _LOGGER.info(
-                "%s: Unrecognized auto lock mode code: %s", self.name, hex(raw_mode)
-            )
-        if mode == 0 and duration == 0:
-            # If both values are 0, auto lock is disabled
-            mode = AutoLockMode.OFF
-        return AutoLockState(mode, duration)
+        """Parse the auto lock state from a READSETTING (setting 0x28) response.
+
+        The auto-lock time is a single little-endian uint32 at
+        ``response[8:12]``; there is no mode byte. A Timed relock is
+        encoded by the lock as ``seconds | (seconds << 16)`` -- the same seconds
+        in both 16-bit halves -- so a non-zero high half signals Timed and
+        carries the seconds. A value with only the low half set is Instant; zero
+        is off. The mode is derived from the value, never read from a wire byte.
+        """
+        value = util._bytes_to_int(response[0x08:0x0C])
+        if value == 0:
+            return AutoLockState(AutoLockMode.OFF, 0)
+        if seconds := (value >> 16) & 0xFFFF:
+            return AutoLockState(AutoLockMode.TIMER, seconds)
+        return AutoLockState(AutoLockMode.INSTANT, value & 0xFFFF)
 
     @raise_if_not_connected
     async def lock_status(self) -> LockStatus:

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import struct
 import time
@@ -70,10 +71,6 @@ RESYNC_DELAY = 0.01
 
 KEEP_ALIVE_TIME = 25.0  # Lock will disconnect after 30 seconds of inactivity
 
-# How many unanswered auto lock setting reads to issue per session before
-# concluding the lock does not support auto lock.
-AUTO_LOCK_READ_ATTEMPTS = 3
-
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
 FIRST_CONNECTION_DISCONNECT_TIME = 2.1
@@ -126,6 +123,37 @@ BATTERY_TIMEOUT_COOLDOWN = 300
 # How often to re-poll battery state in always_connected mode (10 minutes)
 BATTERY_REFRESH_INTERVAL = 600
 
+# How often to re-read the auto lock setting after a successful read (1 hour).
+# Auto lock is configuration state that changes rarely, so an hourly refresh
+# catches an out-of-band change while keeping the read off every keep-alive
+# cycle to save battery. Mirrors BATTERY_REFRESH_INTERVAL.
+AUTO_LOCK_READ_REFRESH_INTERVAL = 3600
+
+# How long to stop reading the auto lock setting after it goes unanswered
+# (24 hours). The state is in memory, so a large value means "until restart".
+# Longer than BATTERY_TIMEOUT_COOLDOWN because an unanswered read points to a
+# lock that does not support the setting, so a long quiet window is wanted.
+AUTO_LOCK_READ_FAILURE_BACKOFF = 86400
+
+# How many consecutive unanswered reads before backing off. Three in a row is
+# the signal the lock does not support the setting; a success resets the count.
+# Ack timeouts and response timeouts both count toward this one threshold.
+AUTO_LOCK_READ_FAILURE_THRESHOLD = 3
+
+# How long to wait for the 0xBB settings response after the READSETTING ack
+# before treating the read as unresolved. The ack completes the solicited wait;
+# the value follows moments later on the notify path. This must clear two bounds:
+# above SLOW_TIMEOUT (the 6s slow-connection supervision timeout, 600 in 10ms
+# units) so a slow but alive link is not struck before it could deliver, and
+# below KEEP_ALIVE_TIME so the next cycle sees it lapsed when the value never
+# comes. Mirrors the session command timeout.
+AUTO_LOCK_READ_RESPONSE_TIMEOUT = 10
+
+# Attempts for the on-demand auto lock write, fewer than DEFAULT_ATTEMPTS. The
+# write is user-initiated and confirmed by the lock's settings response, so a
+# lock that never confirms it should fail fast and report to the user.
+AUTO_LOCK_WRITE_ATTEMPTS = 2
+
 # With BATTERY_TIMEOUT_COOLDOWN it may be possible to remove these
 # exclusions
 NO_BATTERY_SUPPORT_MODELS = {
@@ -173,19 +201,24 @@ class AuthFailureHistory:
 _AUTH_FAILURE_HISTORY = AuthFailureHistory()
 
 
-def retry_bluetooth_connection_error(func: WrapFuncType) -> WrapFuncType:
+def retry_bluetooth_connection_error(
+    func: WrapFuncType | None = None, *, attempts: int = DEFAULT_ATTEMPTS
+) -> Any:
     """
     Define a wrapper to retry on bleak error.
 
     The accessory is allowed to disconnect us any time so
-    we need to retry the operation.
+    we need to retry the operation. Use bare as
+    ``@retry_bluetooth_connection_error`` for the default attempt count, or
+    ``@retry_bluetooth_connection_error(attempts=N)`` to override it.
     """
+    if func is None:
+        return functools.partial(retry_bluetooth_connection_error, attempts=attempts)
 
     async def _async_wrap_retry_bluetooth_connection_error(
         self: PushLock, *args: Any, **kwargs: Any
     ) -> Any:
         _LOGGER.debug("%s: Starting retry loop", self.name)
-        attempts = DEFAULT_ATTEMPTS
         max_attempts = attempts - 1
 
         for attempt in range(attempts):
@@ -294,7 +327,6 @@ class PushLock:
         self._seen_this_session: set[
             type[LockStatus | DoorStatus | BatteryState | AuthState | AutoLockState]
         ] = set()
-        self._auto_lock_read_attempts = 0
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._keep_alive_timer: asyncio.TimerHandle | None = None
         self._idle_disconnect_delay_pending_update = (
@@ -312,6 +344,25 @@ class PushLock:
         self._earliest_battery_attempt_time = NEVER_TIME
         # Scheduled battery refresh time (in always_connected mode)
         self._next_battery_refresh_time = NEVER_TIME
+        # Auto lock read backoff, mirroring the battery timers above. They
+        # persist across reconnects, so a lock that does not answer the read is
+        # left alone until its backoff lapses.
+        # Earliest next auto lock read after repeated unanswered reads.
+        self._earliest_auto_lock_read_time = NEVER_TIME
+        # Scheduled auto lock re-read time (in always_connected mode).
+        self._next_auto_lock_read_time = NEVER_TIME
+        # Consecutive auto lock reads whose READSETTING command timed out.
+        self._auto_lock_read_ack_failures = 0
+        # Consecutive auto lock reads that were acked but whose 0xBB value
+        # never arrived within the response window.
+        self._auto_lock_read_response_failures = 0
+        # Whether a read has been acked and is still waiting for its 0xBB value,
+        # and the deadline by which the value must arrive. Like the counts and
+        # timers above, these persist across reconnects so a lock that answers
+        # the ack but withholds the value still books its response timeout on the
+        # next connection rather than being re-asked forever.
+        self._awaiting_auto_lock_response = False
+        self._auto_lock_response_deadline = NEVER_TIME
 
     @property
     def local_name(self) -> str | None:
@@ -615,7 +666,9 @@ class PushLock:
             self._next_disconnect_delay = self._idle_disconnect_delay
             self._reset_disconnect_timer()
             self._seen_this_session.clear()
-            self._auto_lock_read_attempts = 0
+            # None of the auto lock read state is reset here: the backoff timers,
+            # both failure counts, and the pending-response flag all persist
+            # across reconnects, so the hold outlives the connection.
             self._slow_params_set = False
             return self._client
 
@@ -729,13 +782,13 @@ class PushLock:
                 "%s: Lock did not confirm the auto lock setting write "
                 "after %s attempts; the lock may not support auto lock",
                 self.name,
-                DEFAULT_ATTEMPTS,
+                AUTO_LOCK_WRITE_ATTEMPTS,
             )
             raise TimeoutError(
                 f"{self.name}: Lock did not confirm the auto lock setting write"
             ) from err
 
-    @retry_bluetooth_connection_error
+    @retry_bluetooth_connection_error(attempts=AUTO_LOCK_WRITE_ATTEMPTS)
     async def _set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:
         """Set auto lock setting."""
         if not self._running:
@@ -752,6 +805,16 @@ class PushLock:
             lock = await self._ensure_connected()
             self._cancel_future_update()
             await lock.set_auto_lock(mode, duration)
+            # A confirmed write both proves the lock supports auto lock (clear
+            # any failure backoff) and changes the value: drop AutoLockState and
+            # both deadlines so the next update reads the new value straight
+            # back, confirming the write and refreshing the display.
+            self._auto_lock_read_ack_failures = 0
+            self._auto_lock_read_response_failures = 0
+            self._awaiting_auto_lock_response = False
+            self._earliest_auto_lock_read_time = NEVER_TIME
+            self._next_auto_lock_read_time = NEVER_TIME
+            self._seen_this_session.discard(AutoLockState)
         except Exception as ex:
             # The retry_bluetooth_connection_error wrapper calls
             # _async_handle_disconnected for RETRY_EXCEPTIONS /
@@ -815,6 +878,17 @@ class PushLock:
                 if lock_state.battery != state:
                     changes["battery"] = state
             elif isinstance(state, AutoLockState):
+                # The 0xBB settings response arriving here carries the stored
+                # value and is the success signal for the read backoff: clear
+                # both failure counts, disarm the pending-response deadline the
+                # ack armed, and arm the refresh timer where the value lands.
+                self._auto_lock_read_ack_failures = 0
+                self._auto_lock_read_response_failures = 0
+                self._awaiting_auto_lock_response = False
+                self._earliest_auto_lock_read_time = NEVER_TIME
+                self._next_auto_lock_read_time = (
+                    time.monotonic() + AUTO_LOCK_READ_REFRESH_INTERVAL
+                )
                 if lock_state.auto_lock != state:
                     changes["auto_lock"] = state
                     changes["auto_lock_prev"] = lock_state.auto_lock
@@ -907,7 +981,7 @@ class PushLock:
             )
             # Set cooldown to prevent repeated timeouts.
             self._earliest_battery_attempt_time = now + BATTERY_TIMEOUT_COOLDOWN
-        except (BleakError, BleakDBusError) as err:
+        except BleakError as err:
             _LOGGER.debug(
                 "%s: Battery request failed (%s), continuing with other updates.",
                 self.name,
@@ -935,38 +1009,108 @@ class PushLock:
         _LOGGER.debug("Obtained lock info: %s", lock_info)
         return lock_info
 
+    def _arm_auto_lock_read_backoff_if_exhausted(self, now: float) -> bool:
+        """Arm the read backoff once the failure count hits the limit.
+
+        A lock shows one shape at a time -- either silent to the command (ack
+        timeouts) or acking without the value (response timeouts) -- so only one
+        counter grows. Summing them lets whichever it is trip the one threshold
+        after AUTO_LOCK_READ_FAILURE_THRESHOLD failures in a row.
+        """
+        total = (
+            self._auto_lock_read_ack_failures + self._auto_lock_read_response_failures
+        )
+        if total < AUTO_LOCK_READ_FAILURE_THRESHOLD:
+            return False
+        self._earliest_auto_lock_read_time = now + AUTO_LOCK_READ_FAILURE_BACKOFF
+        _LOGGER.info(
+            "%s: Auto lock setting request unresolved after %s attempts "
+            "(%s ack timeouts, %s response timeouts); the lock may not support "
+            "auto lock; not asking again for %d seconds",
+            self.name,
+            total,
+            self._auto_lock_read_ack_failures,
+            self._auto_lock_read_response_failures,
+            AUTO_LOCK_READ_FAILURE_BACKOFF,
+        )
+        self._auto_lock_read_ack_failures = 0
+        self._auto_lock_read_response_failures = 0
+        return True
+
     async def _read_auto_lock_setting(self, lock: Lock) -> bool:
         """Request the auto lock setting; return whether a read was issued.
 
-        The solicited wait returns the READSETTING acknowledgment, whose
-        value field is zero -- never the stored setting. Issue the read only
-        to trigger the 0xBB settings response, which the notify path decodes
-        and applies; the end-of-update restore in _update carries that value
-        into the cycle's result. A lock that never sends that response would
-        otherwise be asked again on every update cycle, so the read is
-        capped per session; the counter resets on reconnect beside
-        _seen_this_session. Incrementing before the await also bounds a lock
-        that is silent to the command entirely, whose timeout would re-enter
-        here through the update retries.
+        Mirrors _poll_battery's two-timer backoff. The solicited wait returns
+        the READSETTING acknowledgment, whose value field is a fixed zero; the
+        stored setting arrives afterwards on the notify path as the 0xBB
+        settings response. Issue the read only to trigger that response, which
+        the notify path decodes and applies; its arrival is the success signal
+        that arms the refresh timer (see _update_any_state).
+
+        A lock that never gives the value back is caught two ways, both counting
+        toward AUTO_LOCK_READ_FAILURE_THRESHOLD. A lock silent to the command
+        times out on the ack; a lock that acks but withholds the 0xBB leaves the
+        response deadline armed, and the next cycle sees it lapse with the value
+        still unseen. Either way, after THRESHOLD failures in a row the read
+        backs off for AUTO_LOCK_READ_FAILURE_BACKOFF seconds. All of this state
+        lives outside the reconnect reset so it survives disconnects.
         """
+        now = time.monotonic()
+        # Skip while backed off after repeated unanswered reads.
+        if now < self._earliest_auto_lock_read_time:
+            return False
+        # Resolve a read that was acked last cycle but is still waiting for its
+        # 0xBB value. The 0xBB clears this flag on the notify path the moment it
+        # lands, so if it is still set the value has not arrived.
+        if self._awaiting_auto_lock_response:
+            if now <= self._auto_lock_response_deadline:
+                # The value may still be in flight; do not re-read or strike.
+                return False
+            # Acked but the value never came: a response timeout, counted like
+            # an ack timeout. Fall through to re-read unless it armed the backoff.
+            self._awaiting_auto_lock_response = False
+            self._auto_lock_read_response_failures += 1
+            if self._arm_auto_lock_read_backoff_if_exhausted(now):
+                return False
+        # Periodic refresh: evict AutoLockState once its deadline has passed so
+        # the next cycle re-reads (always_connected only, as battery does).
+        if (
+            self._always_connected
+            and AutoLockState in self._seen_this_session
+            and now > self._next_auto_lock_read_time
+        ):
+            self._seen_this_session.discard(AutoLockState)
         if AutoLockState in self._seen_this_session:
             return False
-        if self._auto_lock_read_attempts < AUTO_LOCK_READ_ATTEMPTS:
-            self._auto_lock_read_attempts += 1
+        try:
             await lock.auto_lock_status()
-            return True
-        if self._auto_lock_read_attempts == AUTO_LOCK_READ_ATTEMPTS:
-            # The final increment marks the message as sent so it logs once
-            # per session.
-            self._auto_lock_read_attempts += 1
-            _LOGGER.info(
-                "%s: Auto lock setting request unanswered after %s attempts; "
-                "the lock may not support auto lock; not asking again this "
-                "session",
+        except TimeoutError:
+            # Handle the timeout here, as _poll_battery does. A timeout that
+            # reaches _update's retry decorator is read as a lost connection and
+            # forces a reconnect; catching it locally keeps the connection up
+            # and the read on its backoff.
+            self._auto_lock_read_ack_failures += 1
+            self._arm_auto_lock_read_backoff_if_exhausted(now)
+            return False
+        except BleakError as err:
+            # Mirror _poll_battery: a transport fault leaves the backoff alone
+            # (only a timeout arms it) and the update continues. A persistent
+            # fault surfaces on a later status poll or the disconnect callback.
+            _LOGGER.debug(
+                "%s: Auto lock setting request failed (%s), "
+                "continuing with other updates.",
                 self.name,
-                AUTO_LOCK_READ_ATTEMPTS,
+                err,
             )
-        return False
+            return False
+        # The ack arrived; expect the 0xBB value within the response window --
+        # unless it already landed on the notify path during the await (same
+        # loop turn), in which case AutoLockState is already seen and there is
+        # nothing to wait for, so do not arm a deadline for a value in hand.
+        if AutoLockState not in self._seen_this_session:
+            self._awaiting_auto_lock_response = True
+            self._auto_lock_response_deadline = now + AUTO_LOCK_READ_RESPONSE_TIMEOUT
+        return True
 
     @operation_lock
     @retry_bluetooth_connection_error

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -947,14 +947,14 @@ class PushLock:
 
         if AutoLockState not in self._seen_this_session:
             made_request = True
-            auto_lock_state = await lock.auto_lock_status()
+            # The solicited wait returns the READSETTING acknowledgment,
+            # whose value field is zero -- never the stored setting. Issue
+            # the read only to trigger the 0xBB settings response, which
+            # the notify path decodes and applies; the end-of-update
+            # restore below carries that value into this cycle's result.
+            await lock.auto_lock_status()
             _AUTH_FAILURE_HISTORY.auth_success(self.address)
-            state = replace(
-                state,
-                auto_lock=auto_lock_state,
-                auto_lock_prev=state.auto_lock,
-                auth=AuthState(successful=True),
-            )
+            state = replace(state, auth=AuthState(successful=True))
 
         # Only ask for the lock status if we haven't seen
         # it this session since notify callbacks will happen
@@ -981,6 +981,17 @@ class PushLock:
             state = replace(state, lock=cached_state.lock)
         if state.door == DoorStatus.UNKNOWN and cached_state.door != DoorStatus.UNKNOWN:
             state = replace(state, door=cached_state.door)
+
+        # Auto-lock is owned by the notify path: the 0xBB settings responses
+        # (read and write) publish it mid-update, while the poll's own return
+        # value is the acknowledgment constant and is discarded above. Always
+        # carry the cached value forward so this wholesale application cannot
+        # clobber a value published during the cycle.
+        state = replace(
+            state,
+            auto_lock=cached_state.auto_lock,
+            auto_lock_prev=cached_state.auto_lock_prev,
+        )
 
         self._callback_state(state)
 

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -70,6 +70,10 @@ RESYNC_DELAY = 0.01
 
 KEEP_ALIVE_TIME = 25.0  # Lock will disconnect after 30 seconds of inactivity
 
+# How many unanswered auto lock setting reads to issue per session before
+# concluding the lock does not support auto lock.
+AUTO_LOCK_READ_ATTEMPTS = 3
+
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
 FIRST_CONNECTION_DISCONNECT_TIME = 2.1
@@ -290,6 +294,7 @@ class PushLock:
         self._seen_this_session: set[
             type[LockStatus | DoorStatus | BatteryState | AuthState | AutoLockState]
         ] = set()
+        self._auto_lock_read_attempts = 0
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._keep_alive_timer: asyncio.TimerHandle | None = None
         self._idle_disconnect_delay_pending_update = (
@@ -610,6 +615,7 @@ class PushLock:
             self._next_disconnect_delay = self._idle_disconnect_delay
             self._reset_disconnect_timer()
             self._seen_this_session.clear()
+            self._auto_lock_read_attempts = 0
             self._slow_params_set = False
             return self._client
 
@@ -929,6 +935,39 @@ class PushLock:
         _LOGGER.debug("Obtained lock info: %s", lock_info)
         return lock_info
 
+    async def _read_auto_lock_setting(self, lock: Lock) -> bool:
+        """Request the auto lock setting; return whether a read was issued.
+
+        The solicited wait returns the READSETTING acknowledgment, whose
+        value field is zero -- never the stored setting. Issue the read only
+        to trigger the 0xBB settings response, which the notify path decodes
+        and applies; the end-of-update restore in _update carries that value
+        into the cycle's result. A lock that never sends that response would
+        otherwise be asked again on every update cycle, so the read is
+        capped per session; the counter resets on reconnect beside
+        _seen_this_session. Incrementing before the await also bounds a lock
+        that is silent to the command entirely, whose timeout would re-enter
+        here through the update retries.
+        """
+        if AutoLockState in self._seen_this_session:
+            return False
+        if self._auto_lock_read_attempts < AUTO_LOCK_READ_ATTEMPTS:
+            self._auto_lock_read_attempts += 1
+            await lock.auto_lock_status()
+            return True
+        if self._auto_lock_read_attempts == AUTO_LOCK_READ_ATTEMPTS:
+            # The final increment marks the message as sent so it logs once
+            # per session.
+            self._auto_lock_read_attempts += 1
+            _LOGGER.info(
+                "%s: Auto lock setting request unanswered after %s attempts; "
+                "the lock may not support auto lock; not asking again this "
+                "session",
+                self.name,
+                AUTO_LOCK_READ_ATTEMPTS,
+            )
+        return False
+
     @operation_lock
     @retry_bluetooth_connection_error
     async def _update(self) -> LockState:
@@ -960,14 +999,8 @@ class PushLock:
             _AUTH_FAILURE_HISTORY.auth_success(self.address)
             state = replace(state, door=door_status, auth=AuthState(successful=True))
 
-        if AutoLockState not in self._seen_this_session:
+        if await self._read_auto_lock_setting(lock):
             made_request = True
-            # The solicited wait returns the READSETTING acknowledgment,
-            # whose value field is zero -- never the stored setting. Issue
-            # the read only to trigger the 0xBB settings response, which
-            # the notify path decodes and applies; the end-of-update
-            # restore below carries that value into this cycle's result.
-            await lock.auto_lock_status()
             _AUTH_FAILURE_HISTORY.auth_success(self.address)
             state = replace(state, auth=AuthState(successful=True))
 

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -686,7 +686,7 @@ class PushLock:
             if self.auto_lock and self.auto_lock.mode == AutoLockMode.OFF:
                 _LOGGER.debug("%s: Auto lock is already off", self.name)
                 return
-            await self._set_auto_lock(AutoLockMode.OFF, 0)
+            await self._set_auto_lock_or_warn(AutoLockMode.OFF, 0)
             return
 
         duration = AUTO_LOCK_DEFAULT_DURATION
@@ -695,7 +695,7 @@ class PushLock:
         elif self.auto_lock_prev and self.auto_lock_prev.mode != AutoLockMode.OFF:
             # If the auto lock is currently off, use the previous duration
             duration = self.auto_lock_prev.duration
-        await self._set_auto_lock(mode, duration)
+        await self._set_auto_lock_or_warn(mode, duration)
 
     async def set_auto_lock_duration(self, duration: int) -> None:
         """Set auto lock setting."""
@@ -703,7 +703,7 @@ class PushLock:
             if self.auto_lock and self.auto_lock.mode == AutoLockMode.OFF:
                 _LOGGER.debug("%s: Auto lock is already off", self.name)
                 return
-            await self._set_auto_lock(AutoLockMode.OFF, 0)
+            await self._set_auto_lock_or_warn(AutoLockMode.OFF, 0)
             return
 
         mode = AutoLockMode.TIMER
@@ -712,7 +712,22 @@ class PushLock:
         elif self.auto_lock_prev and self.auto_lock_prev.mode != AutoLockMode.OFF:
             # If the auto lock is currently off, use the previous mode
             mode = self.auto_lock_prev.mode
-        await self._set_auto_lock(mode, duration)
+        await self._set_auto_lock_or_warn(mode, duration)
+
+    async def _set_auto_lock_or_warn(self, mode: AutoLockMode, duration: int) -> None:
+        """Set auto lock, surfacing a write the lock never confirmed."""
+        try:
+            await self._set_auto_lock(mode, duration)
+        except TimeoutError as err:
+            _LOGGER.warning(
+                "%s: Lock did not confirm the auto lock setting write "
+                "after %s attempts; the lock may not support auto lock",
+                self.name,
+                DEFAULT_ATTEMPTS,
+            )
+            raise TimeoutError(
+                f"{self.name}: Lock did not confirm the auto lock setting write"
+            ) from err
 
     @retry_bluetooth_connection_error
     async def _set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -73,6 +73,7 @@ class Session:
         )
         self._notifications_started = False
         self._notify_future: asyncio.Future[bytes] | None = None
+        self._notify_matcher: Callable[[bytes], bool] | None = None
         self._state_callback = state_callback
         self._disconnected_futures = disconnected_futures
         self._first_request = True
@@ -133,10 +134,15 @@ class Session:
         if response[0x00] != 0xBB and response[0x00] != 0xAA:
             raise ResponseError(f"Incorrect flag in response: {response[0x00]}")
 
-    async def _write(self, command: bytearray, command_name: str) -> bytes:
+    async def _write(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
         """Write under the lock."""
         async with self._lock:
-            return await self._locked_write(command, command_name)
+            return await self._locked_write(command, command_name, response_matcher)
 
     def _notify(self, char: int, data: bytearray) -> None:
         self._last_callback_time = time.monotonic()
@@ -160,11 +166,30 @@ class Session:
             _LOGGER.debug("%s: Invalid response, waiting for next one", self.name)
             self._notify_future.set_exception(ex)
             self._notify_future = None
+            self._notify_matcher = None
+            return
+        if self._notify_matcher is not None and not self._notify_matcher(
+            decrypted_data
+        ):
+            # A valid frame, but not the answer this command is waiting for
+            # (for example the 0xAA acknowledgment that precedes a settings response).
+            # It has already been passed to the state callback above; keep the
+            # future armed for the real answer.
+            _LOGGER.debug(
+                "%s: Response is not the awaited frame, waiting for next one",
+                self.name,
+            )
             return
         self._notify_future.set_result(decrypted_data)
         self._notify_future = None
+        self._notify_matcher = None
 
-    async def _locked_write(self, command: bytearray, command_name: str) -> bytes:
+    async def _locked_write(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
         # NOTE: The last two bytes are not encrypted
         # General idea seems to be that if the last byte
         # of the command indicates an offline key offset (is non-zero),
@@ -182,6 +207,7 @@ class Session:
         for attempt in range(3):
             future: asyncio.Future[bytes] = self.loop.create_future()
             self._notify_future = future
+            self._notify_matcher = response_matcher
             _LOGGER.debug(
                 "%s: Writing command to %s: %s",
                 self.name,
@@ -189,19 +215,27 @@ class Session:
                 command.hex(),
             )
             _LOGGER.debug("%s: Waiting for response", self.name)
-            async with util.asyncio_timeout(10):
-                try:
-                    await self.client.write_gatt_char(
-                        self.write_characteristic, command, True
-                    )
-                    result = await future
-                except ResponseError:
-                    if attempt == 2:
-                        raise
-                    _LOGGER.debug("%s: Invalid response, retrying", self.name)
-                    continue
-                else:
-                    break
+            try:
+                async with util.asyncio_timeout(10):
+                    try:
+                        await self.client.write_gatt_char(
+                            self.write_characteristic, command, True
+                        )
+                        result = await future
+                    except ResponseError:
+                        if attempt == 2:
+                            raise
+                        _LOGGER.debug("%s: Invalid response, retrying", self.name)
+                        continue
+                    else:
+                        break
+            except TimeoutError:
+                # The wait expired with the future still armed. Disarm it so a
+                # late frame cannot land on the cancelled future or leak this
+                # command's matcher into a later wait.
+                self._notify_future = None
+                self._notify_matcher = None
+                raise
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
         return result
 
@@ -243,8 +277,20 @@ class Session:
         except BleakError as err:
             _LOGGER.debug("%s: Bleak error stopping notify: %s", self.name, err)
 
-    async def execute(self, command: bytearray, command_name: str) -> bytes:
-        """Execute command."""
+    async def execute(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
+        """Execute command.
+
+        ``response_matcher`` narrows which notify frame answers the command:
+        valid frames that do not match still reach the state callback, but the
+        solicited wait stays armed until a matching frame arrives (or the
+        write times out). Without a matcher the first valid frame answers, as
+        before.
+        """
         while (
             self._enable_cooldown
             and (cooldown_remain := time.monotonic() - self._last_callback_time)
@@ -266,7 +312,7 @@ class Session:
             async with interrupt(
                 disconnected_future, DisconnectedError, f"{self.name}: Disconnected"
             ):
-                return await self._write(command, command_name)
+                return await self._write(command, command_name, response_matcher)
         except BleakError as err:
             if self._first_request and util.is_key_error(err):
                 raise AuthError(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -350,7 +350,7 @@ def _make_lock(
 
 
 def test_parse_auto_lock_state_timed_from_wire() -> None:
-    """Real capture: value 1800 stored as seconds|(seconds<<16) -> Timed 30 min.
+    """Real capture: both uint16 timers set to 1800 -> Timed 30 min.
 
     Front Door READSETTING response, YUR/DEL fw 2.1.0 (2026-07-05 capture).
     """
@@ -374,9 +374,9 @@ def test_parse_auto_lock_state_off_from_wire() -> None:
 def test_parse_auto_lock_state_old_encoding_reads_user_value() -> None:
     """A value written by a release before the two-timer encoding -> Timed 30.
 
-    Earlier releases stored the user's seconds in the never-opened half and a
-    fixed 90 in the door-close half, so Timed(30) was written as 1e 00 5a 00.
-    The decode reports the never-opened half, so the value reads back as set.
+    Earlier releases stored the user's seconds in the never-opened timer and a
+    fixed 90 in the door-close timer, so Timed(30) was written as 1e 00 5a 00.
+    The decode reports the never-opened timer, so the value reads back as set.
     """
     lock = _make_lock()
     response = bytes(8) + bytes.fromhex("1e005a00")
@@ -385,7 +385,7 @@ def test_parse_auto_lock_state_old_encoding_reads_user_value() -> None:
 
 
 def test_parse_auto_lock_state_zero_never_opened_falls_back() -> None:
-    """A zero never-opened half falls back to the door-close half.
+    """A zero never-opened timer falls back to the door-close timer.
 
     Synthetic value exercising the branch; not a captured device value.
     """
@@ -395,8 +395,8 @@ def test_parse_auto_lock_state_zero_never_opened_falls_back() -> None:
     assert result == AutoLockState(AutoLockMode.TIMER, 90)
 
 
-def test_parse_auto_lock_state_instant_low_half_only() -> None:
-    """Derivation branch: low 16 bits set, high half zero -> Instant.
+def test_parse_auto_lock_state_instant_never_opened_only() -> None:
+    """Derivation branch: never-opened timer set, door-close timer zero -> Instant.
 
     Synthetic value exercising the branch; not a captured device value.
     """
@@ -447,8 +447,8 @@ async def _set_auto_lock_payload(mode: AutoLockMode, duration: int) -> bytearray
 
 
 @pytest.mark.asyncio
-async def test_set_auto_lock_timed_encodes_seconds_in_both_halves() -> None:
-    """Timed(1800) -> value = 1800|(1800<<16) -> [8:12] = 08 07 08 07."""
+async def test_set_auto_lock_timed_encodes_seconds_in_both_timers() -> None:
+    """Timed(1800) -> both uint16 timers = 1800 -> [8:12] = 08 07 08 07."""
     cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 1800)
     assert cmd[0x01] == Commands.WRITESETTING.value
     assert cmd[0x04] == 0x28  # auto-lock setting id
@@ -456,8 +456,8 @@ async def test_set_auto_lock_timed_encodes_seconds_in_both_halves() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_auto_lock_instant_encodes_low_half_only() -> None:
-    """Instant(5) -> value = 5 -> [8:12] = 05 00 00 00."""
+async def test_set_auto_lock_instant_encodes_never_opened_only() -> None:
+    """Instant(5) -> never-opened timer = 5, door-close 0 -> [8:12] = 05 00 00 00."""
     cmd = await _set_auto_lock_payload(AutoLockMode.INSTANT, 5)
     assert cmd[0x08:0x0C] == bytes.fromhex("05000000")
 
@@ -471,7 +471,7 @@ async def test_set_auto_lock_off_encodes_zero() -> None:
 
 @pytest.mark.asyncio
 async def test_set_auto_lock_duration_out_of_range_raises() -> None:
-    """Durations must fit a 16-bit half; 0xFFFF+ is rejected (app rule 1-65534)."""
+    """Durations must fit a uint16 timer; 0xFFFF+ is rejected (app rule 1-65534)."""
     with pytest.raises(ValueError, match="out of range"):
         await _set_auto_lock_payload(AutoLockMode.TIMER, 0xFFFF)
 
@@ -491,7 +491,7 @@ async def test_set_auto_lock_round_trips_through_decode() -> None:
 async def test_set_auto_lock_timed_accepts_upper_bound() -> None:
     """Timed(0xFFFE) is the largest accepted duration.
 
-    Both 16-bit halves take the seconds, so [8:12] = 0xFFFE|(0xFFFE<<16).
+    Both uint16 timers take the seconds, so [8:12] = fe ff fe ff.
     """
     cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 0xFFFE)
     assert cmd[0x08:0x0C] == bytes.fromhex("fefffeff")

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -20,10 +20,12 @@ from yalexs_ble.const import (
     LockOperationSource,
     LockStateValue,
     LockStatus,
+    SettingType,
 )
 from yalexs_ble.lock import (
     AA_BATTERY_VOLTAGE_TO_PERCENTAGE,
     Lock,
+    _settings_response_matcher,
     convert_voltage_to_percentage,
 )
 
@@ -398,7 +400,12 @@ class _CommandCaptureSession:
         cmd[0x10] = 0x02
         return cmd
 
-    async def execute(self, command: bytearray, command_name: str) -> bytes:
+    async def execute(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
         self.sent.append(command)
         return b""
 
@@ -465,6 +472,41 @@ def test_parse_state_readsetting_ack_ignored() -> None:
     lock = _make_lock()
     ack = bytes.fromhex("aa0400282800000000000000000000000200")
     assert lock._parse_state(ack) == ()
+
+
+def test_parse_state_writesetting_ack_ignored() -> None:
+    """The WRITESETTING (0x03) transport ACK carries no state -> recognized, ignored.
+
+    Real ACK frame for an auto-lock write of Timed(90) (2026-07-16 capture); the
+    stored value is echoed at [8:12] but the frame is only the acknowledgment --
+    the authoritative echo is the 0xBB frame that follows.
+    """
+    lock = _make_lock()
+    ack = bytes.fromhex("aa030075280000005a005a00000000000200")
+    assert lock._parse_state(ack) == ()
+
+
+def test_settings_response_matcher_takes_value_frame_not_ack() -> None:
+    """The matcher keys on 0xBB + the settings opcode + the setting id.
+
+    All frames verbatim from the 2026-07-16 field capture: a settings command
+    is answered by an 0xAA acknowledgment ~40 ms before the 0xBB value frame,
+    and the acknowledgment's zero value field decodes as auto-lock off.
+    """
+    write_matcher = _settings_response_matcher(
+        Commands.WRITESETTING.value, SettingType.AUTOLOCK.value
+    )
+
+    read_response = bytes.fromhex("bb0400fb2800000008070807000000000000")
+    write_ack = bytes.fromhex("aa030075280000005a005a00000000000200")
+    write_response = bytes.fromhex("bb030066280000005a005a00000000000000")
+    battery_answer = bytes.fromhex("bb0200a50f00000079140000000000000200")
+
+    assert write_matcher(write_response)
+    assert not write_matcher(write_ack)
+    assert not write_matcher(read_response)  # wrong opcode for the write
+    assert not write_matcher(battery_answer)
+    assert not write_matcher(write_response[:4])  # truncated below the setting id
 
 
 _CHAR_DATA: dict[str, bytes] = {

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -371,6 +371,30 @@ def test_parse_auto_lock_state_off_from_wire() -> None:
     assert result == AutoLockState(AutoLockMode.OFF, 0)
 
 
+def test_parse_auto_lock_state_old_encoding_reads_user_value() -> None:
+    """A value written by a release before the two-timer encoding -> Timed 30.
+
+    Earlier releases stored the user's seconds in the never-opened half and a
+    fixed 90 in the door-close half, so Timed(30) was written as 1e 00 5a 00.
+    The decode reports the never-opened half, so the value reads back as set.
+    """
+    lock = _make_lock()
+    response = bytes(8) + bytes.fromhex("1e005a00")
+    result = lock._parse_auto_lock_state(response)
+    assert result == AutoLockState(AutoLockMode.TIMER, 30)
+
+
+def test_parse_auto_lock_state_zero_never_opened_falls_back() -> None:
+    """A zero never-opened half falls back to the door-close half.
+
+    Synthetic value exercising the branch; not a captured device value.
+    """
+    lock = _make_lock()
+    response = bytes(8) + bytes.fromhex("00005a00")
+    result = lock._parse_auto_lock_state(response)
+    assert result == AutoLockState(AutoLockMode.TIMER, 90)
+
+
 def test_parse_auto_lock_state_instant_low_half_only() -> None:
     """Derivation branch: low 16 bits set, high half zero -> Instant.
 
@@ -505,9 +529,7 @@ async def test_set_auto_lock_instant_round_trips_through_decode() -> None:
     lock = _make_lock()
     cmd = await _set_auto_lock_payload(AutoLockMode.INSTANT, 5)
     echoed = bytes([0xBB, 0x04, 0x00, 0x00, 0x28, 0, 0, 0]) + bytes(cmd[0x08:0x0C])
-    assert lock._parse_auto_lock_state(echoed) == AutoLockState(
-        AutoLockMode.INSTANT, 5
-    )
+    assert lock._parse_auto_lock_state(echoed) == AutoLockState(AutoLockMode.INSTANT, 5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -463,6 +463,62 @@ async def test_set_auto_lock_round_trips_through_decode() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_set_auto_lock_timed_accepts_upper_bound() -> None:
+    """Timed(0xFFFE) is the largest accepted duration.
+
+    Both 16-bit halves take the seconds, so [8:12] = 0xFFFE|(0xFFFE<<16).
+    """
+    cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 0xFFFE)
+    assert cmd[0x08:0x0C] == bytes.fromhex("fefffeff")
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_timed_zero_duration_encodes_off_shape() -> None:
+    """Timed with a zero duration collapses to the off shape: an all-zero value."""
+    cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 0)
+    assert cmd[0x08:0x0C] == bytes(4)
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_status_issues_read_and_returns_none() -> None:
+    """auto_lock_status sends a READSETTING for the auto-lock setting.
+
+    The wait completes on the acknowledgment, which carries no value, so the
+    method returns nothing; the stored setting arrives later as a settings
+    response on the notify path.
+    """
+    lock = _make_lock()
+    session = _CommandCaptureSession()
+    lock.session = session  # type: ignore[assignment]
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+    assert await lock.auto_lock_status() is None
+    assert len(session.sent) == 1
+    assert session.sent[0][0x01] == Commands.READSETTING.value
+    assert session.sent[0][0x04] == SettingType.AUTOLOCK.value
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_instant_round_trips_through_decode() -> None:
+    """Instant(5), encoded then decoded, returns Instant(5)."""
+    lock = _make_lock()
+    cmd = await _set_auto_lock_payload(AutoLockMode.INSTANT, 5)
+    echoed = bytes([0xBB, 0x04, 0x00, 0x00, 0x28, 0, 0, 0]) + bytes(cmd[0x08:0x0C])
+    assert lock._parse_auto_lock_state(echoed) == AutoLockState(
+        AutoLockMode.INSTANT, 5
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_off_round_trips_through_decode() -> None:
+    """Off, encoded then decoded, returns Off with a zero duration."""
+    lock = _make_lock()
+    cmd = await _set_auto_lock_payload(AutoLockMode.OFF, 0)
+    echoed = bytes([0xBB, 0x04, 0x00, 0x00, 0x28, 0, 0, 0]) + bytes(cmd[0x08:0x0C])
+    assert lock._parse_auto_lock_state(echoed) == AutoLockState(AutoLockMode.OFF, 0)
+
+
 def test_parse_state_readsetting_ack_ignored() -> None:
     """The READSETTING (0x04) transport ACK carries no state -> recognized, ignored.
 
@@ -479,7 +535,7 @@ def test_parse_state_writesetting_ack_ignored() -> None:
 
     Real ACK frame for an auto-lock write of Timed(90) (2026-07-16 capture); the
     stored value is echoed at [8:12] but the frame is only the acknowledgment --
-    the authoritative echo is the 0xBB frame that follows.
+    the authoritative value is the 0xBB settings response that follows.
     """
     lock = _make_lock()
     ack = bytes.fromhex("aa030075280000005a005a00000000000200")

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -14,6 +14,7 @@ from yalexs_ble.const import (
     VALUE_TO_LOCK_STATUS,
     AutoLockMode,
     AutoLockState,
+    Commands,
     LockInfo,
     LockOperationRemoteType,
     LockOperationSource,
@@ -377,6 +378,82 @@ def test_parse_auto_lock_state_instant_low_half_only() -> None:
     response = bytes(8) + (0x0005).to_bytes(4, "little")
     result = lock._parse_auto_lock_state(response)
     assert result == AutoLockState(AutoLockMode.INSTANT, 5)
+
+
+class _CommandCaptureSession:
+    """Minimal Session stand-in that captures executed commands.
+
+    build_operation_command mirrors Session's 18-byte frame layout
+    (EE, opcode, cmd byte at [4], ClearText trailer marker at [16]).
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[bytearray] = []
+
+    def build_operation_command(self, opcode: int, cmd_byte: int) -> bytearray:
+        cmd = bytearray(0x12)
+        cmd[0x00] = 0xEE
+        cmd[0x01] = opcode
+        cmd[0x04] = cmd_byte
+        cmd[0x10] = 0x02
+        return cmd
+
+    async def execute(self, command: bytearray, command_name: str) -> bytes:
+        self.sent.append(command)
+        return b""
+
+
+async def _set_auto_lock_payload(mode: AutoLockMode, duration: int) -> bytearray:
+    """Run set_auto_lock against a capture session; return the sent command."""
+    lock = _make_lock()
+    session = _CommandCaptureSession()
+    lock.session = session  # type: ignore[assignment]
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+    await lock.set_auto_lock(mode, duration)
+    assert len(session.sent) == 1
+    return session.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_timed_encodes_seconds_in_both_halves() -> None:
+    """Timed(1800) -> value = 1800|(1800<<16) -> [8:12] = 08 07 08 07."""
+    cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 1800)
+    assert cmd[0x01] == Commands.WRITESETTING.value
+    assert cmd[0x04] == 0x28  # auto-lock setting id
+    assert cmd[0x08:0x0C] == bytes.fromhex("08070807")
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_instant_encodes_low_half_only() -> None:
+    """Instant(5) -> value = 5 -> [8:12] = 05 00 00 00."""
+    cmd = await _set_auto_lock_payload(AutoLockMode.INSTANT, 5)
+    assert cmd[0x08:0x0C] == bytes.fromhex("05000000")
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_off_encodes_zero() -> None:
+    """Off -> value = 0 regardless of the duration argument."""
+    cmd = await _set_auto_lock_payload(AutoLockMode.OFF, 1800)
+    assert cmd[0x08:0x0C] == bytes(4)
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_duration_out_of_range_raises() -> None:
+    """Durations must fit a 16-bit half; 0xFFFF+ is rejected (app rule 1-65534)."""
+    with pytest.raises(ValueError, match="out of range"):
+        await _set_auto_lock_payload(AutoLockMode.TIMER, 0xFFFF)
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_round_trips_through_decode() -> None:
+    """A value we write, echoed back by the lock, decodes to what we set."""
+    lock = _make_lock()
+    cmd = await _set_auto_lock_payload(AutoLockMode.TIMER, 1800)
+    echoed = bytes([0xBB, 0x04, 0x00, 0x00, 0x28, 0, 0, 0]) + bytes(cmd[0x08:0x0C])
+    assert lock._parse_auto_lock_state(echoed) == AutoLockState(
+        AutoLockMode.TIMER, 1800
+    )
 
 
 def test_parse_state_readsetting_ack_ignored() -> None:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -564,6 +564,21 @@ def test_parse_state_writesetting_ack_ignored() -> None:
     assert lock._parse_state(ack) == ()
 
 
+def test_parse_state_ack_for_other_opcode_is_unknown() -> None:
+    """ACK recognition is scoped to the settings opcodes.
+
+    An 0xAA frame whose opcode is neither a lock/unlock ack nor a settings ack
+    is not claimed: it falls through to None, so a new acknowledgment type on
+    another model still surfaces as an unknown frame instead of being silently
+    dropped. Frame built from the READSETTING ACK capture above with the opcode
+    byte changed to LOCK_ACTIVITY (0x2D), which is recognized on the 0xBB flag
+    only.
+    """
+    lock = _make_lock()
+    ack = bytes.fromhex("aa2d00282800000000000000000000000200")
+    assert lock._parse_state(ack) is None
+
+
 def test_settings_response_matcher_takes_value_frame_not_ack() -> None:
     """The matcher keys on 0xBB + the settings opcode + the setting id.
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -505,7 +505,7 @@ async def test_set_auto_lock_timed_zero_duration_encodes_off_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auto_lock_status_issues_read_and_returns_none() -> None:
+async def test_auto_lock_status_issues_read() -> None:
     """auto_lock_status sends a READSETTING for the auto-lock setting.
 
     The wait completes on the acknowledgment, which carries no value, so the
@@ -517,7 +517,7 @@ async def test_auto_lock_status_issues_read_and_returns_none() -> None:
     lock.session = session  # type: ignore[assignment]
     lock.secure_session = MagicMock()
     lock.client = MagicMock(is_connected=True)
-    assert await lock.auto_lock_status() is None
+    await lock.auto_lock_status()
     assert len(session.sent) == 1
     assert session.sent[0][0x01] == Commands.READSETTING.value
     assert session.sent[0][0x04] == SettingType.AUTOLOCK.value

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -316,25 +316,6 @@ def test_parse_ack_still_reports_state() -> None:
     assert list(result) == [LockStatus.LOCKED]
 
 
-def test_parse_settings_read_ack_is_none_and_logs_unknown(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """An AA ack echoing a non-operation command is not recognized as state.
-
-    Production capture: the ack to the startup auto-lock READSETTING (command
-    0x04 echoed in byte[1], setting 0x28 in byte[4]). Only the Lock/Unlock
-    acks carry a state meaning; other acks surface via the unknown-state log.
-    """
-    lock = _make_lock()
-
-    frame = bytes.fromhex("aa0400282800000000000000000000000200")
-    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
-        assert lock._parse_state(frame) is None
-        lock._internal_state_callback(frame)
-
-    assert "Unknown state" in caplog.text
-
-
 def test_internal_state_callback_emits_recognized_state() -> None:
     """A recognized frame with state content reaches the state callback."""
     received: list[list[LockStateValue]] = []
@@ -353,11 +334,6 @@ def test_jammed_maps_to_the_settled_static_position_value() -> None:
     assert VALUE_TO_LOCK_STATUS[0x07] is LockStatus.JAMMED
 
 
-def _make_auto_lock_response(mode_byte: int, duration: int) -> bytes:
-    """Build a minimal _parse_auto_lock_state response buffer."""
-    return bytes(8) + duration.to_bytes(2, "little") + bytes([mode_byte])
-
-
 def _make_lock(
     state_callback: Callable[[Iterable[LockStateValue]], None] = lambda _: None,
 ) -> Lock:
@@ -370,33 +346,48 @@ def _make_lock(
     )
 
 
-def test_parse_auto_lock_state_known_mode() -> None:
-    """Known mode byte returns the matching AutoLockMode with its duration."""
+def test_parse_auto_lock_state_timed_from_wire() -> None:
+    """Real capture: value 1800 stored as seconds|(seconds<<16) -> Timed 30 min.
+
+    Front Door READSETTING response, YUR/DEL fw 2.1.0 (2026-07-05 capture).
+    """
     lock = _make_lock()
-    response = _make_auto_lock_response(AutoLockMode.TIMER, 30)
+    response = bytes.fromhex("bb0400fb2800000008070807000000000000")
     result = lock._parse_auto_lock_state(response)
-    assert result == AutoLockState(AutoLockMode.TIMER, 30)
+    assert result == AutoLockState(AutoLockMode.TIMER, 1800)
 
 
-def test_parse_auto_lock_state_unknown_mode_logs_and_returns_off(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Unrecognized mode byte falls back to OFF and logs a warning."""
+def test_parse_auto_lock_state_off_from_wire() -> None:
+    """Real capture: all-zero setting value -> auto-lock off.
+
+    Back Door READSETTING response (2026-07-05 capture).
+    """
     lock = _make_lock()
-    response = _make_auto_lock_response(0xAB, 15)
-    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
-        result = lock._parse_auto_lock_state(response)
-    assert result.mode is AutoLockMode.OFF
-    assert "0xab" in caplog.text.lower()
-
-
-def test_parse_auto_lock_state_both_zero_means_disabled() -> None:
-    """When mode byte maps to 0 (INSTANT) and duration is 0, state is OFF."""
-    lock = _make_lock()
-    response = _make_auto_lock_response(AutoLockMode.INSTANT, 0)
+    response = bytes.fromhex("bb0400192800000000000000000000000000")
     result = lock._parse_auto_lock_state(response)
-    assert result.mode is AutoLockMode.OFF
-    assert result.duration == 0
+    assert result == AutoLockState(AutoLockMode.OFF, 0)
+
+
+def test_parse_auto_lock_state_instant_low_half_only() -> None:
+    """Derivation branch: low 16 bits set, high half zero -> Instant.
+
+    Synthetic value exercising the branch; not a captured device value.
+    """
+    lock = _make_lock()
+    response = bytes(8) + (0x0005).to_bytes(4, "little")
+    result = lock._parse_auto_lock_state(response)
+    assert result == AutoLockState(AutoLockMode.INSTANT, 5)
+
+
+def test_parse_state_readsetting_ack_ignored() -> None:
+    """The READSETTING (0x04) transport ACK carries no state -> recognized, ignored.
+
+    Real ACK frame for an auto-lock READSETTING (2026-07-05 capture); must return
+    an empty iterable (not None), so it is never logged as an unknown frame.
+    """
+    lock = _make_lock()
+    ack = bytes.fromhex("aa0400282800000000000000000000000200")
+    assert lock._parse_state(ack) == ()
 
 
 _CHAR_DATA: dict[str, bytes] = {

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1341,3 +1341,32 @@ async def test_retry_backoff_exceptions_sleep_between_attempts() -> None:
         with pytest.raises(TimeoutError):
             await op_nobackoff(lock2)
         assert sleep_mock.await_args_list == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("setter", ["set_auto_lock_duration", "set_auto_lock_mode"])
+async def test_set_auto_lock_timeout_warns_and_names_the_failure(
+    caplog: pytest.LogCaptureFixture, setter: str
+) -> None:
+    """An unconfirmed auto lock write warns once and re-raises with a message."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0b",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+
+    with patch.object(push_lock, "_set_auto_lock", new_callable=AsyncMock) as mock_set:
+        mock_set.side_effect = TimeoutError()
+        with pytest.raises(TimeoutError) as exc_info:
+            if setter == "set_auto_lock_duration":
+                await push_lock.set_auto_lock_duration(30)
+            else:
+                await push_lock.set_auto_lock_mode(AutoLockMode.TIMER)
+
+    assert "Lock did not confirm the auto lock setting write" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "the lock may not support auto lock" in warnings[0].getMessage()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -494,6 +494,82 @@ async def test_update_preserves_notify_state_from_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_auto_lock_from_notify_path_survives_poll_result() -> None:
+    """_update() carries the notify-published auto-lock into its final state.
+
+    The auto-lock read's return value is the READSETTING acknowledgment
+    constant (OFF) and is discarded; the stored setting arrives as the 0xBB
+    settings response on the notify path during the cycle. The end-of-update
+    restore must apply the notify-published value, not revert to the cycle's
+    starting snapshot or the poll constant.
+    """
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:ff",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+
+    push_lock._lock_state = LockState(
+        lock=LockStatus.LOCKED,
+        door=DoorStatus.CLOSED,
+        battery=None,
+        auth=None,
+        auto_lock=None,
+        auto_lock_prev=None,
+    )
+
+    mock_lock = MagicMock()
+    push_lock._lock_info = MagicMock(model="ASL-03", door_sense=True)
+    push_lock._running = True
+
+    # Mark everything but AutoLockState seen so only the auto-lock read runs.
+    push_lock._seen_this_session.add(LockStatus)
+    push_lock._seen_this_session.add(DoorStatus)
+    push_lock._seen_this_session.add(BatteryState)
+
+    push_lock._advertisement_data = AdvertisementData(
+        local_name="Test Lock",
+        service_data={},
+        service_uuids=[],
+        rssi=-50,
+        manufacturer_data={},
+        platform_data=(),
+        tx_power=0,
+    )
+
+    # Gate the read so the settings-response notify publish lands mid-cycle.
+    auto_lock_in_progress = asyncio.Event()
+    allow_auto_lock_to_continue = asyncio.Event()
+
+    async def auto_lock_status():
+        auto_lock_in_progress.set()
+        await allow_auto_lock_to_continue.wait()
+        # The acknowledgment constant -- must not reach the final state.
+        return AutoLockState(mode=AutoLockMode.OFF, duration=0)
+
+    mock_lock.auto_lock_status = AsyncMock(side_effect=auto_lock_status)
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        update_task = asyncio.create_task(push_lock._update())
+
+        await auto_lock_in_progress.wait()
+        # The 0xBB settings response publishing through the notify path.
+        push_lock._update_any_state([AutoLockState(AutoLockMode.TIMER, 1800)])
+        allow_auto_lock_to_continue.set()
+
+        final_state = await update_task
+
+        assert final_state.auto_lock == AutoLockState(AutoLockMode.TIMER, 1800), (
+            f"Auto-lock should be the notify-published value, "
+            f"got {final_state.auto_lock}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_update_continues_when_lock_info_probe_fails() -> None:
     """Test that _update() proceeds with defaults when lock_info() raises."""
     push_lock = PushLock(

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1370,3 +1370,92 @@ async def test_set_auto_lock_timeout_warns_and_names_the_failure(
     warnings = [record for record in caplog.records if record.levelname == "WARNING"]
     assert len(warnings) == 1
     assert "the lock may not support auto lock" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("setter", "arg", "auto_lock", "auto_lock_prev", "expected"),
+    [
+        # Turning auto lock off writes OFF with a zero duration.
+        ("set_auto_lock_mode", AutoLockMode.OFF, None, None, (AutoLockMode.OFF, 0)),
+        ("set_auto_lock_duration", 0, None, None, (AutoLockMode.OFF, 0)),
+        # Already off returns without writing.
+        (
+            "set_auto_lock_mode",
+            AutoLockMode.OFF,
+            AutoLockState(mode=AutoLockMode.OFF, duration=0),
+            None,
+            None,
+        ),
+        (
+            "set_auto_lock_duration",
+            0,
+            AutoLockState(mode=AutoLockMode.OFF, duration=0),
+            None,
+            None,
+        ),
+        # A mode change keeps the current duration; a duration change keeps
+        # the current mode.
+        (
+            "set_auto_lock_mode",
+            AutoLockMode.INSTANT,
+            AutoLockState(mode=AutoLockMode.TIMER, duration=120),
+            None,
+            (AutoLockMode.INSTANT, 120),
+        ),
+        (
+            "set_auto_lock_duration",
+            60,
+            AutoLockState(mode=AutoLockMode.INSTANT, duration=5),
+            None,
+            (AutoLockMode.INSTANT, 60),
+        ),
+        # When auto lock is currently off, fall back to the previous state.
+        (
+            "set_auto_lock_mode",
+            AutoLockMode.TIMER,
+            AutoLockState(mode=AutoLockMode.OFF, duration=0),
+            AutoLockState(mode=AutoLockMode.TIMER, duration=300),
+            (AutoLockMode.TIMER, 300),
+        ),
+        (
+            "set_auto_lock_duration",
+            60,
+            AutoLockState(mode=AutoLockMode.OFF, duration=0),
+            AutoLockState(mode=AutoLockMode.INSTANT, duration=10),
+            (AutoLockMode.INSTANT, 60),
+        ),
+    ],
+)
+async def test_set_auto_lock_wrappers_choose_the_written_pair(
+    setter: str,
+    arg: AutoLockMode | int,
+    auto_lock: AutoLockState | None,
+    auto_lock_prev: AutoLockState | None,
+    expected: tuple[AutoLockMode, int] | None,
+) -> None:
+    """The public setters pick mode and duration from current, then previous state."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0c",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    if auto_lock or auto_lock_prev:
+        push_lock._lock_state = LockState(
+            lock=LockStatus.LOCKED,
+            door=DoorStatus.CLOSED,
+            battery=None,
+            auth=None,
+            auto_lock=auto_lock,
+            auto_lock_prev=auto_lock_prev,
+        )
+
+    with patch.object(push_lock, "_set_auto_lock", new_callable=AsyncMock) as mock_set:
+        await getattr(push_lock, setter)(arg)
+
+    if expected is None:
+        mock_set.assert_not_awaited()
+    else:
+        mock_set.assert_awaited_once_with(*expected)

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -1459,3 +1460,89 @@ async def test_set_auto_lock_wrappers_choose_the_written_pair(
         mock_set.assert_not_awaited()
     else:
         mock_set.assert_awaited_once_with(*expected)
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_latches_after_unanswered_attempts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The settings read stops after three unanswered attempts per session."""
+    caplog.set_level(logging.INFO)
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0d",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+
+    mock_lock = MagicMock()
+    mock_lock.lock_info = AsyncMock(return_value=TEST_LOCK_INFO)
+    mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=6.0, percentage=80))
+    mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+    mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
+
+    push_lock._lock_info = TEST_LOCK_INFO
+    push_lock._running = True
+    push_lock._advertisement_data = AdvertisementData(
+        local_name="Test Lock",
+        service_data={},
+        service_uuids=[],
+        rssi=-50,
+        manufacturer_data={},
+        platform_data=(),
+        tx_power=0,
+    )
+
+    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
+        # The response never arrives, so AutoLockState never enters
+        # _seen_this_session; the read must stop after three attempts.
+        for _ in range(5):
+            await push_lock._update()
+
+    assert mock_lock.auto_lock_status.await_count == 3
+    latch_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO
+        and "may not support auto lock" in record.getMessage()
+    ]
+    assert len(latch_records) == 1
+
+    # A new session resets the counter and the read resumes.
+    push_lock._auto_lock_read_attempts = 0
+    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
+        await push_lock._update()
+    assert mock_lock.auto_lock_status.await_count == 4
+
+    # Once the state has been seen, the read is not issued at all.
+    push_lock._seen_this_session.add(AutoLockState)
+    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
+        await push_lock._update()
+    assert mock_lock.auto_lock_status.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_connect_resets_the_auto_lock_read_counter() -> None:
+    """A new session grants the settings read a fresh set of attempts."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0e",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    push_lock._auto_lock_read_attempts = 4
+    push_lock._seen_this_session.add(AutoLockState)
+
+    mock_lock = MagicMock()
+    mock_lock.connect = AsyncMock()
+
+    with patch.object(push_lock, "_get_lock_instance", return_value=mock_lock):
+        client = await push_lock._ensure_connected()
+
+    assert client is mock_lock
+    assert push_lock._auto_lock_read_attempts == 0
+    assert AutoLockState not in push_lock._seen_this_session
+    push_lock._cancel_disconnect_timer()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -4,10 +4,12 @@ import time
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakDBusError, BleakError
 
 from yalexs_ble.const import (
+    AuthState,
     AutoLockMode,
     AutoLockState,
     BatteryState,
@@ -16,9 +18,15 @@ from yalexs_ble.const import (
     LockState,
     LockStatus,
 )
+from yalexs_ble.lock import Lock
 from yalexs_ble.push import (
     _AUTH_FAILURE_HISTORY,
     AUTH_FAILURE_TO_START_REAUTH,
+    AUTO_LOCK_READ_FAILURE_BACKOFF,
+    AUTO_LOCK_READ_FAILURE_THRESHOLD,
+    AUTO_LOCK_READ_REFRESH_INTERVAL,
+    AUTO_LOCK_READ_RESPONSE_TIMEOUT,
+    AUTO_LOCK_WRITE_ATTEMPTS,
     BATTERY_REFRESH_INTERVAL,
     DEFAULT_ATTEMPTS,
     NEVER_TIME,
@@ -27,6 +35,7 @@ from yalexs_ble.push import (
     SLOW_MAX_INTERVAL,
     SLOW_MIN_INTERVAL,
     SLOW_TIMEOUT,
+    YALE_MFR_ID,
     PushLock,
     operation_lock,
     retry_bluetooth_connection_error,
@@ -1353,6 +1362,7 @@ async def test_set_auto_lock_timeout_warns_and_names_the_failure(
     warnings = [record for record in caplog.records if record.levelname == "WARNING"]
     assert len(warnings) == 1
     assert "the lock may not support auto lock" in warnings[0].getMessage()
+    assert f"after {AUTO_LOCK_WRITE_ATTEMPTS} attempts" in warnings[0].getMessage()
 
 
 @pytest.mark.asyncio
@@ -1444,14 +1454,233 @@ async def test_set_auto_lock_wrappers_choose_the_written_pair(
         mock_set.assert_awaited_once_with(*expected)
 
 
+@pytest.mark.parametrize("always_connected", [False, True])
 @pytest.mark.asyncio
-async def test_auto_lock_read_latches_after_unanswered_attempts(
-    caplog: pytest.LogCaptureFixture,
+async def test_auto_lock_read_backoff_arms_after_threshold_timeouts(
+    always_connected: bool, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """The settings read stops after three unanswered attempts per session."""
+    """The read backs off only after THRESHOLD consecutive timeouts, not before.
+
+    The arm path is mode-independent, so it is exercised with and without
+    always_connected for symmetry with the response-timeout arming test.
+    """
     caplog.set_level(logging.INFO)
     push_lock = PushLock(
         address="aa:bb:cc:dd:ee:0d",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=always_connected,
+    )
+    push_lock._name = "Test Lock"
+
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(side_effect=TimeoutError)
+
+    # Below the threshold: each timeout is counted, but the backoff is not armed.
+    for expected in range(1, AUTO_LOCK_READ_FAILURE_THRESHOLD):
+        assert await push_lock._read_auto_lock_setting(mock_lock) is False
+        assert push_lock._auto_lock_read_ack_failures == expected
+        assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+    assert not [
+        r for r in caplog.records if "may not support auto lock" in r.getMessage()
+    ]
+
+    # The threshold-th consecutive timeout arms the backoff and logs once.
+    # Arming restarts the count, so the field reads zero afterwards.
+    before = time.monotonic()
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert (
+        push_lock._earliest_auto_lock_read_time
+        >= before + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    latch = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "may not support auto lock" in r.getMessage()
+    ]
+    assert len(latch) == 1
+    assert mock_lock.auto_lock_status.await_count == AUTO_LOCK_READ_FAILURE_THRESHOLD
+
+    # Now backed off: the read is skipped without ever touching the lock.
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert mock_lock.auto_lock_status.await_count == AUTO_LOCK_READ_FAILURE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_backoff_reearned_after_window() -> None:
+    """When the backoff window expires the count restarts and is re-earned."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0d",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    # Arriving as if a prior window has just armed and reset: no failures held,
+    # and the window is already past so reads resume.
+    push_lock._auto_lock_read_ack_failures = 0
+    push_lock._earliest_auto_lock_read_time = NEVER_TIME
+
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(side_effect=TimeoutError)
+
+    # A fresh run of consecutive timeouts is needed to arm the backoff again.
+    for expected in range(1, AUTO_LOCK_READ_FAILURE_THRESHOLD):
+        assert await push_lock._read_auto_lock_setting(mock_lock) is False
+        assert push_lock._auto_lock_read_ack_failures == expected
+        assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+
+    before = time.monotonic()
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert (
+        push_lock._earliest_auto_lock_read_time
+        >= before + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    assert mock_lock.auto_lock_status.await_count == AUTO_LOCK_READ_FAILURE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_success_resets_failure_count() -> None:
+    """A settings response arriving clears the failures and arms the refresh."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0d",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    push_lock._auto_lock_read_ack_failures = AUTO_LOCK_READ_FAILURE_THRESHOLD - 1
+    push_lock._auto_lock_read_response_failures = 1
+    push_lock._awaiting_auto_lock_response = True
+    push_lock._auto_lock_response_deadline = time.monotonic() + 10.0
+    push_lock._earliest_auto_lock_read_time = time.monotonic() + 100.0
+
+    before = time.monotonic()
+    push_lock._update_any_state([AutoLockState(mode=AutoLockMode.TIMER, duration=30)])
+
+    # The value landing -- not the read call returning -- is the success signal:
+    # it clears both failure counts and disarms the pending-response deadline.
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert push_lock._auto_lock_read_response_failures == 0
+    assert push_lock._awaiting_auto_lock_response is False
+    assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+    assert (
+        push_lock._next_auto_lock_read_time >= before + AUTO_LOCK_READ_REFRESH_INTERVAL
+    )
+    assert AutoLockState in push_lock._seen_this_session
+    assert push_lock.auto_lock == AutoLockState(mode=AutoLockMode.TIMER, duration=30)
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_backoff_survives_reconnect() -> None:
+    """The failure backoff outlives a reconnect -- the W2 regression guard."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0e",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=True,
+    )
+    push_lock._name = "Test Lock"
+    deadline = time.monotonic() + AUTO_LOCK_READ_FAILURE_BACKOFF
+    push_lock._earliest_auto_lock_read_time = deadline
+    push_lock._auto_lock_read_ack_failures = AUTO_LOCK_READ_FAILURE_THRESHOLD
+    push_lock._seen_this_session.add(AutoLockState)
+
+    mock_lock = MagicMock()
+    mock_lock.connect = AsyncMock()
+    mock_lock.auto_lock_status = AsyncMock(side_effect=TimeoutError)
+
+    with patch.object(push_lock, "_get_lock_instance", return_value=mock_lock):
+        client = await push_lock._ensure_connected()
+
+    # The reconnect cleared _seen_this_session but must NOT clear the backoff.
+    assert AutoLockState not in push_lock._seen_this_session
+    assert push_lock._earliest_auto_lock_read_time == deadline
+    assert push_lock._auto_lock_read_ack_failures == AUTO_LOCK_READ_FAILURE_THRESHOLD
+
+    # Still backed off after the reconnect: the read stays skipped, so the
+    # case-2 storm cannot restart.
+    assert await push_lock._read_auto_lock_setting(client) is False
+    mock_lock.auto_lock_status.assert_not_called()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_refresh_evicts_only_when_due() -> None:
+    """The refresh re-reads only after the interval, mirroring the battery refresh."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:0f",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=True,
+    )
+    push_lock._name = "Test Lock"
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+    push_lock._seen_this_session.add(AutoLockState)
+
+    # Not yet due: the seen gate holds, no re-read.
+    push_lock._next_auto_lock_read_time = (
+        time.monotonic() + AUTO_LOCK_READ_REFRESH_INTERVAL
+    )
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert AutoLockState in push_lock._seen_this_session
+    mock_lock.auto_lock_status.assert_not_called()
+
+    # Deadline passed: evict AutoLockState and issue a fresh read.
+    push_lock._next_auto_lock_read_time = time.monotonic() - 1.0
+    assert await push_lock._read_auto_lock_setting(mock_lock) is True
+    mock_lock.auto_lock_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_no_evict_outside_always_connected() -> None:
+    """Outside always_connected mode the refresh never evicts a seen value."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:10",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+    push_lock._seen_this_session.add(AutoLockState)
+    # Deadline long past, but the eviction is gated on always_connected.
+    push_lock._next_auto_lock_read_time = time.monotonic() - 1.0
+
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert AutoLockState in push_lock._seen_this_session
+    mock_lock.auto_lock_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_transport_error_does_not_arm_backoff() -> None:
+    """A transport fault mirrors _poll_battery: skip without arming the backoff."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:14",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(side_effect=BleakError("boom"))
+
+    # A non-timeout fault is not the "alive but silent" signature: the read is
+    # skipped, but the failure count and backoff are left untouched.
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_timeout_does_not_propagate_out_of_update() -> None:
+    """A read timeout is caught in the helper, so _update completes normally."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:11",
         key="0800200c9a66",
         key_index=1,
         always_connected=False,
@@ -1462,7 +1691,7 @@ async def test_auto_lock_read_latches_after_unanswered_attempts(
     mock_lock.lock_info = AsyncMock(return_value=TEST_LOCK_INFO)
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=6.0, percentage=80))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+    mock_lock.auto_lock_status = AsyncMock(side_effect=TimeoutError)
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
 
     push_lock._lock_info = TEST_LOCK_INFO
@@ -1478,53 +1707,463 @@ async def test_auto_lock_read_latches_after_unanswered_attempts(
     )
 
     with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
-        # The response never arrives, so AutoLockState never enters
-        # _seen_this_session; the read must stop after three attempts.
-        for _ in range(5):
-            await push_lock._update()
+        state = await push_lock._update()
 
-    assert mock_lock.auto_lock_status.await_count == 3
-    latch_records = [
-        record
-        for record in caplog.records
-        if record.levelno == logging.INFO
-        and "may not support auto lock" in record.getMessage()
-    ]
-    assert len(latch_records) == 1
-
-    # A new session resets the counter and the read resumes.
-    push_lock._auto_lock_read_attempts = 0
-    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
-        await push_lock._update()
-    assert mock_lock.auto_lock_status.await_count == 4
-
-    # Once the state has been seen, the read is not issued at all.
-    push_lock._seen_this_session.add(AutoLockState)
-    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
-        await push_lock._update()
-    assert mock_lock.auto_lock_status.await_count == 4
+    # The update returned instead of raising: no forced disconnect, and the
+    # timeout was counted as a failure rather than propagated.
+    assert state.lock == LockStatus.LOCKED
+    assert push_lock._auto_lock_read_ack_failures == 1
+    mock_lock.auto_lock_status.assert_awaited_once()
+    push_lock._cancel_disconnect_timer()
 
 
 @pytest.mark.asyncio
-async def test_connect_resets_the_auto_lock_read_counter() -> None:
-    """A new session grants the settings read a fresh set of attempts."""
+async def test_set_auto_lock_write_resets_read_backoff() -> None:
+    """A confirmed write clears the backoff and evicts the seen value."""
     push_lock = PushLock(
-        address="aa:bb:cc:dd:ee:0e",
+        address="aa:bb:cc:dd:ee:12",
         key="0800200c9a66",
         key_index=1,
         always_connected=False,
     )
     push_lock._name = "Test Lock"
-    push_lock._auto_lock_read_attempts = 4
+    push_lock._running = True
+    push_lock._auto_lock_read_ack_failures = AUTO_LOCK_READ_FAILURE_THRESHOLD
+    push_lock._auto_lock_read_response_failures = 2
+    push_lock._awaiting_auto_lock_response = True
+    push_lock._auto_lock_response_deadline = time.monotonic() + 10.0
+    push_lock._earliest_auto_lock_read_time = (
+        time.monotonic() + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    push_lock._next_auto_lock_read_time = (
+        time.monotonic() + AUTO_LOCK_READ_REFRESH_INTERVAL
+    )
+    push_lock._seen_this_session.add(AutoLockState)
+
+    mock_lock = MagicMock()
+    mock_lock.set_auto_lock = AsyncMock()
+
+    with (
+        patch.object(push_lock, "_ensure_connected", return_value=mock_lock),
+        patch.object(push_lock, "_complete_operation"),
+    ):
+        await push_lock._set_auto_lock(AutoLockMode.TIMER, 30)
+
+    mock_lock.set_auto_lock.assert_awaited_once_with(AutoLockMode.TIMER, 30)
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert push_lock._auto_lock_read_response_failures == 0
+    assert push_lock._awaiting_auto_lock_response is False
+    assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+    assert push_lock._next_auto_lock_read_time == NEVER_TIME
+    assert AutoLockState not in push_lock._seen_this_session
+
+    # With the value evicted and no backoff, the next read is issued again.
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+    assert await push_lock._read_auto_lock_setting(mock_lock) is True
+
+
+# ---------------------------------------------------------------------------
+# Auto lock read: the four settings-command outcomes (see
+# notes/yale/autolock_settings_command_outcome_taxonomy.md), each with and
+# without always_connected, plus dropout and advert-driven connect-on-demand.
+#
+#   Case 1 -- dead lock, answers nothing. Caught by the earlier unguarded reads
+#            in _update, so the auto lock read is never reached.
+#   Case 2 -- alive but silent to the read: the ack times out.
+#   Case 3 -- acks the read but withholds the 0xBB value: the response window
+#            lapses with the value unseen.
+#   Case 4 -- full working lock: ack, then the 0xBB value on the notify path.
+# ---------------------------------------------------------------------------
+
+
+def _auto_lock_push_lock(address: str, *, always_connected: bool) -> PushLock:
+    """A named PushLock for the auto lock read outcome tests."""
+    push_lock = PushLock(
+        address=address,
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=always_connected,
+    )
+    push_lock._name = "Test Lock"
+    return push_lock
+
+
+def _auto_lock_update_lock(auto_lock_status: AsyncMock) -> MagicMock:
+    """A mock Lock answering every read so _update reaches the auto lock read.
+
+    The auto lock read itself is wired per the outcome under test.
+    """
+    lock = MagicMock()
+    lock.connect = AsyncMock()
+    lock.is_connected = True
+    lock.battery = AsyncMock(return_value=BatteryState(voltage=6.0, percentage=80))
+    lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
+    lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
+    lock.auto_lock_status = auto_lock_status
+    return lock
+
+
+@pytest.mark.parametrize("always_connected", [False, True])
+@pytest.mark.asyncio
+async def test_auto_lock_read_response_timeout_arms_backoff(
+    always_connected: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Case 3: the lock acks the read but withholds the 0xBB value.
+
+    The read completes on the ack, so no timeout fires; the pending-response
+    deadline lapses on the next cycle with the value still unseen. After
+    THRESHOLD such response timeouts in a row the read backs off, and the INFO
+    log reports the ack and response counts separately.
+    """
+    caplog.set_level(logging.INFO)
+    push_lock = _auto_lock_push_lock(
+        "aa:bb:cc:dd:ee:20", always_connected=always_connected
+    )
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)  # ack ok, no 0xBB
+
+    # First cycle issues the read and arms the pending-response deadline.
+    assert await push_lock._read_auto_lock_setting(mock_lock) is True
+    assert push_lock._awaiting_auto_lock_response is True
+    assert push_lock._auto_lock_read_response_failures == 0
+
+    # Each later cycle finds the window lapsed with the value still unseen: a
+    # response timeout, which re-reads until the threshold is reached.
+    for expected in range(1, AUTO_LOCK_READ_FAILURE_THRESHOLD):
+        push_lock._auto_lock_response_deadline = time.monotonic() - 1.0
+        assert await push_lock._read_auto_lock_setting(mock_lock) is True
+        assert push_lock._auto_lock_read_response_failures == expected
+        assert push_lock._auto_lock_read_ack_failures == 0
+        assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+
+    # The threshold-th response timeout arms the backoff and logs the breakdown.
+    push_lock._auto_lock_response_deadline = time.monotonic() - 1.0
+    before = time.monotonic()
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert push_lock._auto_lock_read_response_failures == 0
+    assert (
+        push_lock._earliest_auto_lock_read_time
+        >= before + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    latch = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO
+        and f"0 ack timeouts, {AUTO_LOCK_READ_FAILURE_THRESHOLD} response timeouts"
+        in r.getMessage()
+    ]
+    assert len(latch) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_value_in_flight_holds_without_strike() -> None:
+    """Case 3 timing: within the response window the read waits, not strikes.
+
+    Before the deadline the 0xBB may still be in flight, so the read neither
+    books a response timeout nor issues another read.
+    """
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:21", always_connected=True)
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(return_value=None)
+
+    assert await push_lock._read_auto_lock_setting(mock_lock) is True  # arms pending
+    mock_lock.auto_lock_status.reset_mock()
+
+    # Still inside the window (deadline is ~now + AUTO_LOCK_READ_RESPONSE_TIMEOUT).
+    assert push_lock._auto_lock_response_deadline > time.monotonic()
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    mock_lock.auto_lock_status.assert_not_awaited()
+    assert push_lock._awaiting_auto_lock_response is True
+    assert push_lock._auto_lock_read_response_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_value_landing_during_ack_does_not_arm_pending() -> None:
+    """A 0xBB that lands in the same loop turn as the ack is not waited on.
+
+    If the notify path delivers the value before the read coroutine resumes,
+    AutoLockState is already seen, so the read must not arm a pending-response
+    deadline for a value already in hand -- otherwise the next cycle would book
+    one spurious response timeout.
+    """
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:2a", always_connected=True)
+
+    def _ack_and_value(*_args: object) -> None:
+        # The 0xBB is dispatched on the notify path before the await resumes.
+        push_lock._update_any_state(
+            [AutoLockState(mode=AutoLockMode.TIMER, duration=30)]
+        )
+
+    mock_lock = MagicMock()
+    mock_lock.auto_lock_status = AsyncMock(side_effect=_ack_and_value)
+
+    assert await push_lock._read_auto_lock_setting(mock_lock) is True
+    assert push_lock._awaiting_auto_lock_response is False
+    assert AutoLockState in push_lock._seen_this_session
+
+    # A later cycle finds the value already seen, not a phantom pending read.
+    assert await push_lock._read_auto_lock_setting(mock_lock) is False
+    assert push_lock._auto_lock_read_response_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_pending_survives_reconnect() -> None:
+    """Dropout: a reconnect mid-read keeps the pending-response state.
+
+    The hold must outlive the connection, so the pending flag, its deadline, and
+    the response count all persist across the reconnect that clears the seen set.
+    """
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:23", always_connected=True)
+    deadline = time.monotonic() + AUTO_LOCK_READ_RESPONSE_TIMEOUT
+    push_lock._awaiting_auto_lock_response = True
+    push_lock._auto_lock_response_deadline = deadline
+    push_lock._auto_lock_read_response_failures = 1
     push_lock._seen_this_session.add(AutoLockState)
 
     mock_lock = MagicMock()
     mock_lock.connect = AsyncMock()
+    mock_lock.is_connected = True
 
     with patch.object(push_lock, "_get_lock_instance", return_value=mock_lock):
-        client = await push_lock._ensure_connected()
+        await push_lock._ensure_connected()
 
-    assert client is mock_lock
-    assert push_lock._auto_lock_read_attempts == 0
+    # The reconnect cleared _seen_this_session but preserved the pending state.
     assert AutoLockState not in push_lock._seen_this_session
+    assert push_lock._awaiting_auto_lock_response is True
+    assert push_lock._auto_lock_response_deadline == deadline
+    assert push_lock._auto_lock_read_response_failures == 1
     push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.parametrize("always_connected", [False, True])
+@pytest.mark.asyncio
+async def test_auto_lock_read_success_ack_then_value(always_connected: bool) -> None:
+    """Case 4: a full working lock. The ack arms the pending-response deadline;
+    the 0xBB value landing afterwards clears it and arms the refresh timer."""
+    push_lock = _auto_lock_push_lock(
+        "aa:bb:cc:dd:ee:24", always_connected=always_connected
+    )
+    push_lock._lock_info = TEST_LOCK_INFO
+    mock_lock = _auto_lock_update_lock(AsyncMock(return_value=None))
+
+    before = time.monotonic()
+    with patch.object(push_lock, "_ensure_connected", return_value=mock_lock):
+        await push_lock._update()
+
+    # The ack completed the read and armed both the pending flag and its
+    # deadline; the value has not arrived yet. The flag is read into a typed
+    # local so asserting it True does not narrow the later is-False check away.
+    mock_lock.auto_lock_status.assert_awaited_once()
+    armed: bool = push_lock._awaiting_auto_lock_response
+    assert armed is True
+    assert push_lock._auto_lock_response_deadline > before
+    assert AutoLockState not in push_lock._seen_this_session
+
+    # The 0xBB then lands on the notify path and clears the pending state.
+    push_lock._update_any_state([AutoLockState(mode=AutoLockMode.TIMER, duration=30)])
+    cleared: bool = push_lock._awaiting_auto_lock_response
+    assert cleared is False
+    assert AutoLockState in push_lock._seen_this_session
+    assert (
+        push_lock._next_auto_lock_read_time >= before + AUTO_LOCK_READ_REFRESH_INTERVAL
+    )
+    assert push_lock.auto_lock == AutoLockState(mode=AutoLockMode.TIMER, duration=30)
+    push_lock._cancel_disconnect_timer()
+    push_lock._cancel_keepalive_timer()
+
+
+@pytest.mark.asyncio
+async def test_update_any_state_auth_change_is_applied() -> None:
+    """An AuthState change through _update_any_state updates the auth field.
+
+    Covers the auth branch of _update_any_state, which sits directly beside the
+    auto lock success block; the two share the "if lock_state.x != state" shape,
+    so an inserted auto lock block anchors against the auth branch in the diff.
+    """
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:29", always_connected=False)
+    assert push_lock._get_current_state().auth is None
+
+    push_lock._update_any_state([AuthState(successful=True)])
+
+    assert push_lock.auth == AuthState(successful=True)
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_response_backoff_survives_connect_on_demand(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Case 3 under connect-on-demand: the hold outlives each connection.
+
+    A not-always-connected lock that acks the read but withholds the value
+    idle-disconnects between adverts. Each advert reconnects (clearing the seen
+    set), yet the pending state and response count carry across, so the response
+    backoff still latches instead of the read repeating on every connection.
+    """
+    caplog.set_level(logging.INFO)
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:25", always_connected=False)
+
+    async def _advert_connect() -> Lock:
+        # A fresh advert-driven connection: was disconnected, now reconnects,
+        # which clears _seen_this_session exactly as _update's connect does.
+        push_lock._client = None
+        lock = MagicMock()
+        lock.connect = AsyncMock()
+        lock.is_connected = True
+        lock.auto_lock_status = AsyncMock(return_value=None)  # ack ok, no 0xBB
+        with patch.object(push_lock, "_get_lock_instance", return_value=lock):
+            return await push_lock._ensure_connected()
+
+    # First connection: the read is issued and the pending deadline armed.
+    client = await _advert_connect()
+    assert await push_lock._read_auto_lock_setting(client) is True
+
+    # Each later connection: the inter-advert gap lapsed the window, so the
+    # withheld value books a response timeout that survived the reconnect.
+    for expected in range(1, AUTO_LOCK_READ_FAILURE_THRESHOLD):
+        push_lock._auto_lock_response_deadline = time.monotonic() - 1.0
+        client = await _advert_connect()
+        assert push_lock._awaiting_auto_lock_response is True  # survived reconnect
+        assert await push_lock._read_auto_lock_setting(client) is True
+        assert push_lock._auto_lock_read_response_failures == expected
+        assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+
+    # The threshold connection finally arms the backoff.
+    push_lock._auto_lock_response_deadline = time.monotonic() - 1.0
+    client = await _advert_connect()
+    before = time.monotonic()
+    assert await push_lock._read_auto_lock_setting(client) is False
+    assert (
+        push_lock._earliest_auto_lock_read_time
+        >= before + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_ack_backoff_survives_connect_on_demand() -> None:
+    """Case 2 under connect-on-demand: a lock silent to the read accumulates ack
+    timeouts across reconnects and backs off, rather than being re-asked on
+    every connection."""
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:26", always_connected=False)
+
+    async def _advert_connect() -> Lock:
+        push_lock._client = None
+        lock = MagicMock()
+        lock.connect = AsyncMock()
+        lock.is_connected = True
+        lock.auto_lock_status = AsyncMock(side_effect=TimeoutError)
+        with patch.object(push_lock, "_get_lock_instance", return_value=lock):
+            return await push_lock._ensure_connected()
+
+    for expected in range(1, AUTO_LOCK_READ_FAILURE_THRESHOLD):
+        client = await _advert_connect()
+        assert await push_lock._read_auto_lock_setting(client) is False
+        assert push_lock._auto_lock_read_ack_failures == expected
+        assert push_lock._earliest_auto_lock_read_time == NEVER_TIME
+
+    client = await _advert_connect()
+    before = time.monotonic()
+    assert await push_lock._read_auto_lock_setting(client) is False
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert (
+        push_lock._earliest_auto_lock_read_time
+        >= before + AUTO_LOCK_READ_FAILURE_BACKOFF
+    )
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_auto_lock_read_connects_after_advertisement() -> None:
+    """Connect-on-demand wiring: an advertisement drives the connect, then the
+    read runs on that connection.
+
+    The lock is disconnected; an advertisement arrives and schedules the update;
+    the deferred update connects on demand and issues the auto lock read.
+    """
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:27", always_connected=False)
+    push_lock._lock_info = TEST_LOCK_INFO
+    push_lock._running = True
+    mock_lock = _auto_lock_update_lock(AsyncMock(return_value=None))
+    ble_device = BLEDevice(push_lock.address, "Test Lock", None)
+    ad = AdvertisementData(
+        local_name="Test Lock",
+        service_data={},
+        service_uuids=[],
+        rssi=-50,
+        manufacturer_data={YALE_MFR_ID: b"\x01"},
+        platform_data=(),
+        tx_power=0,
+    )
+
+    with patch.object(push_lock, "_get_lock_instance", return_value=mock_lock):
+        # The advertisement schedules a connect-on-demand update.
+        push_lock.update_advertisement(ble_device, ad)
+        assert push_lock._cancel_deferred_update is not None
+        # Drive the scheduled update to completion.
+        push_lock._deferred_update()
+        assert push_lock._update_task is not None
+        await push_lock._update_task
+
+    # The connect happened after the advertisement, and the read ran on it.
+    mock_lock.connect.assert_awaited()
+    mock_lock.auto_lock_status.assert_awaited_once()
+    assert push_lock._awaiting_auto_lock_response is True
+    push_lock._running = False
+    push_lock._cancel_disconnect_timer()
+    push_lock._cancel_keepalive_timer()
+
+
+@pytest.mark.parametrize("always_connected", [False, True])
+@pytest.mark.asyncio
+async def test_dead_lock_read_not_reached_earlier_read_propagates(
+    always_connected: bool,
+) -> None:
+    """Case 1: a dead lock answers nothing. The unguarded door read runs before
+    the auto lock read in _update and its timeout propagates (the connection
+    layer handles the dead lock), so the auto lock read is never reached and its
+    counters stay clean.
+    """
+    push_lock = _auto_lock_push_lock(
+        "aa:bb:cc:dd:ee:28", always_connected=always_connected
+    )
+    push_lock._lock_info = TEST_LOCK_INFO
+    mock_lock = _auto_lock_update_lock(AsyncMock(return_value=None))
+    mock_lock.door_status = AsyncMock(side_effect=TimeoutError)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", return_value=mock_lock),
+        pytest.raises(TimeoutError),
+    ):
+        await push_lock._update()
+
+    mock_lock.auto_lock_status.assert_not_awaited()
+    assert push_lock._auto_lock_read_ack_failures == 0
+    assert push_lock._auto_lock_read_response_failures == 0
+    assert push_lock._awaiting_auto_lock_response is False
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_set_auto_lock_write_retries_twice_then_gives_up() -> None:
+    """The write retries AUTO_LOCK_WRITE_ATTEMPTS times, not the default four."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:13",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    push_lock._running = True
+
+    mock_lock = MagicMock()
+    mock_lock.set_auto_lock = AsyncMock(side_effect=ResponseError("no confirmation"))
+
+    with (
+        patch.object(push_lock, "_ensure_connected", return_value=mock_lock),
+        patch.object(push_lock, "_async_handle_disconnected", new_callable=AsyncMock),
+        patch("yalexs_ble.push.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(ResponseError),
+    ):
+        await push_lock._set_auto_lock(AutoLockMode.TIMER, 30)
+
+    assert mock_lock.set_auto_lock.await_count == AUTO_LOCK_WRITE_ATTEMPTS

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -2144,8 +2144,19 @@ async def test_dead_lock_read_not_reached_earlier_read_propagates(
 
 
 @pytest.mark.asyncio
-async def test_set_auto_lock_write_retries_twice_then_gives_up() -> None:
-    """The write retries AUTO_LOCK_WRITE_ATTEMPTS times, not the default four."""
+@pytest.mark.parametrize(
+    "error",
+    [ResponseError("no confirmation"), TimeoutError("no confirmation")],
+)
+async def test_set_auto_lock_write_retries_twice_then_gives_up(
+    error: Exception,
+) -> None:
+    """The write retries AUTO_LOCK_WRITE_ATTEMPTS times, not the default four.
+
+    A stalled write surfaces as either a ResponseError or, when the settings
+    response never lands, a TimeoutError; both are retryable, so the count holds
+    for the actual field failure as well as the synthetic one.
+    """
     push_lock = PushLock(
         address="aa:bb:cc:dd:ee:13",
         key="0800200c9a66",
@@ -2156,13 +2167,13 @@ async def test_set_auto_lock_write_retries_twice_then_gives_up() -> None:
     push_lock._running = True
 
     mock_lock = MagicMock()
-    mock_lock.set_auto_lock = AsyncMock(side_effect=ResponseError("no confirmation"))
+    mock_lock.set_auto_lock = AsyncMock(side_effect=error)
 
     with (
         patch.object(push_lock, "_ensure_connected", return_value=mock_lock),
         patch.object(push_lock, "_async_handle_disconnected", new_callable=AsyncMock),
         patch("yalexs_ble.push.asyncio.sleep", new_callable=AsyncMock),
-        pytest.raises(ResponseError),
+        pytest.raises(type(error)),
     ):
         await push_lock._set_auto_lock(AutoLockMode.TIMER, 30)
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -206,9 +206,7 @@ async def test_update_continues_after_battery_timeout():
 
     # But other calls succeed
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
 
     push_lock._lock_info = TEST_LOCK_INFO
@@ -586,9 +584,7 @@ async def test_update_continues_when_lock_info_probe_fails() -> None:
     mock_lock.lock_info = AsyncMock(side_effect=TimeoutError("probe timed out"))
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=6.0, percentage=80))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
 
     push_lock._advertisement_data = AdvertisementData(
@@ -639,9 +635,7 @@ async def test_update_continues_when_lock_info_probe_bleak_error() -> None:
     )
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=6.0, percentage=80))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
 
     push_lock._advertisement_data = AdvertisementData(
@@ -684,9 +678,7 @@ async def test_update_sets_slow_connection_params_when_always_connected():
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=5.5, percentage=95))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
 
     push_lock._lock_info = TEST_LOCK_INFO
     push_lock._advertisement_data = AdvertisementData(
@@ -727,9 +719,7 @@ async def test_update_does_not_set_connection_params_when_not_always_connected()
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=5.5, percentage=95))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
 
     push_lock._lock_info = TEST_LOCK_INFO
     push_lock._advertisement_data = AdvertisementData(
@@ -770,9 +760,7 @@ async def test_update_handles_connection_params_failure():
     mock_lock.battery = AsyncMock(return_value=BatteryState(voltage=5.5, percentage=95))
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
 
     push_lock._lock_info = TEST_LOCK_INFO
     push_lock._advertisement_data = AdvertisementData(
@@ -811,9 +799,7 @@ async def test_battery_refresh_clears_seen_and_repoll_when_due():
     mock_lock.battery = AsyncMock(return_value=battery_state)
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.client = MagicMock()
     mock_lock.client.set_connection_params = AsyncMock()
 
@@ -864,9 +850,7 @@ async def test_battery_refresh_not_due_skips_repoll():
     mock_lock.battery = AsyncMock()
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.client = MagicMock()
     mock_lock.client.set_connection_params = AsyncMock()
 
@@ -912,9 +896,7 @@ async def test_battery_refresh_does_not_fire_when_not_always_connected():
     mock_lock.battery = AsyncMock()
     mock_lock.lock_status = AsyncMock(return_value=LockStatus.LOCKED)
     mock_lock.door_status = AsyncMock(return_value=DoorStatus.CLOSED)
-    mock_lock.auto_lock_status = AsyncMock(
-        return_value=AutoLockState(mode=AutoLockMode.OFF, duration=0)
-    )
+    mock_lock.auto_lock_status = AsyncMock()
     mock_lock.client = MagicMock()
     mock_lock.client.set_connection_params = AsyncMock()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -151,9 +151,11 @@ async def test_locked_write_clears_slot_on_timeout() -> None:
     # The write succeeds but no notify is ever delivered.
     session.client.write_gatt_char = AsyncMock()
 
-    with patch.object(util, "asyncio_timeout", _short_timeout):
-        with pytest.raises(TimeoutError):
-            await session._locked_write(bytearray(18), "auto_lock_status")
+    with (
+        patch.object(util, "asyncio_timeout", _short_timeout),
+        pytest.raises(TimeoutError),
+    ):
+        await session._locked_write(bytearray(18), "auto_lock_status")
 
     assert session._notify_future is None
     assert session._notify_matcher is None
@@ -170,9 +172,11 @@ async def test_late_notify_after_timeout_is_ignored() -> None:
     session = _make_session(received)
     session.client.write_gatt_char = AsyncMock()
 
-    with patch.object(util, "asyncio_timeout", _short_timeout):
-        with pytest.raises(TimeoutError):
-            await session._locked_write(bytearray(18), "auto_lock_status")
+    with (
+        patch.object(util, "asyncio_timeout", _short_timeout),
+        pytest.raises(TimeoutError),
+    ):
+        await session._locked_write(bytearray(18), "auto_lock_status")
 
     assert session._notify_future is None
     session._notify(0, bytearray(READ_ANSWER))
@@ -188,9 +192,11 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
     session = _make_session(received)
     session.client.write_gatt_char = AsyncMock()
 
-    with patch.object(util, "asyncio_timeout", _short_timeout):
-        with pytest.raises(TimeoutError):
-            await session._locked_write(bytearray(18), "auto_lock_status")
+    with (
+        patch.object(util, "asyncio_timeout", _short_timeout),
+        pytest.raises(TimeoutError),
+    ):
+        await session._locked_write(bytearray(18), "auto_lock_status")
     assert session._notify_future is None
 
     async def deliver(*_args: object, **_kwargs: object) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,120 @@
+"""Session-level tests for the solicited-response matcher."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from yalexs_ble.const import Commands, SettingType
+from yalexs_ble.lock import _settings_response_matcher
+from yalexs_ble.session import ResponseError, Session
+
+# Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
+# acknowledgment and, ~40 ms later, the 0xBB frame carrying the stored value
+# (Timed 1800 as seconds|(seconds<<16)).
+READ_ACK = bytes.fromhex("aa0400282800000000000000000000000200")
+READ_ANSWER = bytes.fromhex("bb0400fb2800000008070807000000000000")
+# The same value frame with its checksum byte cleared, so _validate_response
+# rejects it the way a corrupted frame off the air is rejected.
+CORRUPT_ANSWER = bytes.fromhex("bb0400002800000008070807000000000000")
+
+
+def _make_session(received: list[bytes]) -> Session:
+    """Create a Session with a mock client and pass-through crypto."""
+    client = MagicMock(is_connected=True)
+    session = Session(client, "testlock", asyncio.Lock(), set(), received.append)
+    session.decrypt = bytes  # type: ignore[method-assign, assignment]
+    session.cipher_encrypt = MagicMock(update=bytes)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_settings_wait_skips_ack_and_completes_on_value_frame() -> None:
+    """With a matcher, the acknowledgment does not answer the command.
+
+    The 0xAA acknowledgment arrives first and must leave the wait armed (its
+    zero value field would decode as auto-lock off); the 0xBB settings frame
+    resolves it. Both frames still reach the state callback.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    matcher = _settings_response_matcher(
+        Commands.READSETTING.value, SettingType.AUTOLOCK.value
+    )
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        # The wait is armed before the GATT write, so both response frames
+        # can be delivered from here, in their on-air order.
+        session._notify(0, bytearray(READ_ACK))
+        # The acknowledgment must not have resolved the wait.
+        assert session._notify_future is not None
+        session._notify(0, bytearray(READ_ANSWER))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(bytearray(18), "auto_lock_status", matcher)
+
+    assert result == READ_ANSWER
+    assert received == [READ_ACK, READ_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_execute_without_matcher_takes_first_valid_frame() -> None:
+    """Without a matcher the first valid frame answers, as before."""
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(READ_ACK))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(bytearray(18), "auto_lock_status")
+
+    assert result == READ_ACK
+
+
+@pytest.mark.asyncio
+async def test_corrupt_frame_disarms_the_wait_and_the_command_is_retried() -> None:
+    """A frame that fails the checksum ends the wait, and the write is repeated.
+
+    The corrupt frame resolves the future with a ResponseError, so the matcher
+    must be cleared with it -- otherwise the retry re-arms the wait with the
+    previous command's matcher still in place.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    matcher = _settings_response_matcher(
+        Commands.READSETTING.value, SettingType.AUTOLOCK.value
+    )
+    frames = [CORRUPT_ANSWER, READ_ANSWER]
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(frames.pop(0)))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(bytearray(18), "auto_lock_status", matcher)
+
+    assert result == READ_ANSWER
+    assert session.client.write_gatt_char.await_count == 2
+    # Both frames reached the state callback; only the valid one answered.
+    assert received == [CORRUPT_ANSWER, READ_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_corrupt_frame_on_every_attempt_raises_and_leaves_the_slot_empty() -> (
+    None
+):
+    """Three corrupt frames exhaust the retries and the error reaches the caller."""
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(CORRUPT_ANSWER))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+
+    with pytest.raises(ResponseError):
+        await session._locked_write(bytearray(18), "auto_lock_status")
+
+    assert session.client.write_gatt_char.await_count == 3
+    assert session._notify_future is None
+    assert session._notify_matcher is None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,7 +12,7 @@ from yalexs_ble.session import ResponseError, Session
 
 # Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
 # acknowledgment and, ~40 ms later, the 0xBB frame carrying the stored value
-# (Timed 1800 as seconds|(seconds<<16)).
+# (Timed 1800: both uint16 timers set to 1800).
 READ_ACK = bytes.fromhex("aa0400282800000000000000000000000200")
 READ_ANSWER = bytes.fromhex("bb0400fb2800000008070807000000000000")
 # The same value frame with its checksum byte cleared, so _validate_response

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,10 +1,11 @@
 """Session-level tests for the solicited-response matcher."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from yalexs_ble import util
 from yalexs_ble.const import Commands, SettingType
 from yalexs_ble.lock import _settings_response_matcher
 from yalexs_ble.session import ResponseError, Session
@@ -118,3 +119,85 @@ async def test_corrupt_frame_on_every_attempt_raises_and_leaves_the_slot_empty()
     assert session.client.write_gatt_char.await_count == 3
     assert session._notify_future is None
     assert session._notify_matcher is None
+
+
+def _short_timeout(_seconds: float) -> object:
+    """Replacement for util.asyncio_timeout that expires almost immediately."""
+    return asyncio.timeout(0.01)
+
+
+@pytest.mark.asyncio
+async def test_locked_write_clears_slot_on_success() -> None:
+    """On the happy path the notify slot is empty when _locked_write returns."""
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(READ_ANSWER))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session._locked_write(bytearray(18), "auto_lock_status")
+
+    assert result == READ_ANSWER
+    assert session._notify_future is None
+    assert session._notify_matcher is None
+
+
+@pytest.mark.asyncio
+async def test_locked_write_clears_slot_on_timeout() -> None:
+    """When no response arrives, the timeout path disarms the notify slot."""
+    received: list[bytes] = []
+    session = _make_session(received)
+    # The write succeeds but no notify is ever delivered.
+    session.client.write_gatt_char = AsyncMock()
+
+    with patch.object(util, "asyncio_timeout", _short_timeout):
+        with pytest.raises(TimeoutError):
+            await session._locked_write(bytearray(18), "auto_lock_status")
+
+    assert session._notify_future is None
+    assert session._notify_matcher is None
+
+
+@pytest.mark.asyncio
+async def test_late_notify_after_timeout_is_ignored() -> None:
+    """A frame arriving after the timeout cleared the slot is a no-op.
+
+    The timeout leaves ``_notify_future`` at None, so a late frame reaches the
+    state callback but resolves no wait and raises nothing.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    session.client.write_gatt_char = AsyncMock()
+
+    with patch.object(util, "asyncio_timeout", _short_timeout):
+        with pytest.raises(TimeoutError):
+            await session._locked_write(bytearray(18), "auto_lock_status")
+
+    assert session._notify_future is None
+    session._notify(0, bytearray(READ_ANSWER))
+    assert session._notify_future is None
+    # The late frame still reached the state callback.
+    assert received == [READ_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_fresh_command_rearms_slot_after_timeout() -> None:
+    """After a timeout, a fresh command re-arms the slot and completes normally."""
+    received: list[bytes] = []
+    session = _make_session(received)
+    session.client.write_gatt_char = AsyncMock()
+
+    with patch.object(util, "asyncio_timeout", _short_timeout):
+        with pytest.raises(TimeoutError):
+            await session._locked_write(bytearray(18), "auto_lock_status")
+    assert session._notify_future is None
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(READ_ANSWER))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session._locked_write(bytearray(18), "auto_lock_status")
+
+    assert result == READ_ANSWER
+    assert session._notify_future is None


### PR DESCRIPTION
## What is fixed
Auto-lock's relock parameter is two little-endian 16-bit timers side by side: one that fires if the door is never opened, and one that fires once the door has closed.  A "Timed" duration setting stores the same number of seconds in both.  Previously a "Timed" duration set through `set_auto_lock` always set the door closed relock timer to 90 (0x5a).

The lock's actual settings are now reported. Previously the initial values for the locks auto-lock settings were reported as OFF until the library wrote a new value to the lock and this value was reflected back as the lock's new settings. The source of this is the assumption that commands terminate on the next notification. Unlike GETSTATUS(0xee02) which replies with a singleton Response(0xbb02), READSETTING(0xee04) responds with an Ack(0xaa04) followed by the Response(0xbb04). 

## Breaking change

Before this fix the door-close auto-lock time was always written as a fixed 90 seconds rather than the configured value; the configured value only applied when the door was never opened. Re-saving the auto-lock setting writes the configured value to both timers. Configurations written by earlier releases still read back and display as the value the user set, because the decode reports the never-opened half, the same field those releases wrote.

## Implementation

**Reading the setting**

The complexity of the implementation is due to the requirement to not introduce a new dependency on the lock supporting auto-lock and returning a Response. The new READSETTING code is designed to be robust and tolerate missing Ack and Response frames without locking up the _update polling loop. auto_lock_status() now completes on the Ack(0xaa04) and returns None; its job is to trigger the Response(0xbb04), whose value the notification path decodes and publishes. The change reuses a guard _update already has: at the end of the cycle it re-reads the cached state (cached_state = self._get_current_state()) and restores lock and door from it. Auto-lock now joins that block. The ordering makes this reliable. The 0xbb04 response is already on its way when the library sends the lock-status poll that follows, and the lock delivers command responses in order. And if a response were ever delivered after the update finished, the listener would simply publish it then.

The read is scheduled the way the battery poll already is, on deadlines that survive reconnects;  the counters and deadlines are not reset when  a reconnect resets, so the hold also survives reconnects that happen for any other reason.

| Command | Frames from the lock | Meaning | Handling |
| --- | --- | --- | --- |
| Read | Nothing (the wait times out) | The lock is silent to this one command, though it answered the battery and door reads moments earlier | Counted as one failure. The read handles its own timeout instead of raising it out of the update, so the update carries on and no reconnect fires |
| Read | AA 04 only, no BB 04 within 10 seconds | The lock acknowledges the read but never sends the value | Nothing raises and nothing waits: the command already completed on the acknowledgement, and a later cycle notices the lapsed deadline; counted as one failure |
| Read | Three failures in a row, of either kind | The lock does not support the setting | The read is held off for 24 hours, on a deadline a reconnect does not clear |
| Read | AA 04, then BB 04 | The setting is supported; the BB 04 holds the stored value | The notification path publishes the value and the failure counts clear; the next re-read runs on the next fresh session, or an hour out within an always_connected session |
| Write | AA 03 only, no BB 03 | The lock accepted the command but never confirmed the setting | The wait for the BB 03 times out and is retried once (two attempts in total), then a warning and a raised error reach the caller; the read's failure counts are untouched |
| Write | AA 03, then BB 03 | The write is confirmed; the BB 03 holds the value as the lock stored it | The call returns, any failure hold is cleared, and the next update reads the value straight back |

**Writing the setting**

Writing the setting by comparison is straightforward; set_auto_lock passes a response matcher so the solicited wait holds out for the BB 03 rather than finishing on the AA 03, and runs at two attempts. A confirmed write clears the failure hold, since the lock has just proved it supports the setting, and schedules an immediate read-back so the displayed value is the lock's own. An unconfirmed write warns and raises rather than pretending success, and it leaves the read's failure counts alone: a lock that never confirms writes may still answer reads, and the failed call has already reported itself. The write does not stamp the value optimistically; the notification path stays the single source.

The value a write sends is the two little-endian uint16 timers, laid consecutively at `[8:12]` of the frame:

| Setting | `[8:10]` never-opened timer | `[10:12]` door-close timer | Behaviour |
| --- | --- | --- | --- |
| Off | 0 | 0 | no auto-lock |
| Instant, n | n | 0 | relocks as the door closes; after n seconds if the door is never opened |
| Timed, n | n | n | relocks n seconds after the door closes; after n seconds if the door is never opened |

There is no mode byte: the mode is implied by which timers are set (both zero is off, door-close set is timed, otherwise instant), and the reported duration is the never-opened half, the field the app displays and the field earlier releases wrote.

**Lock, unlock, and unlatch**

The operation commands have the same two-frame answer: an AA acknowledgement when the command is accepted, then a BB operation response with the result when the motor stops. They still complete on the acknowledgement and are deliberately untouched here; completing them on their operation responses is the subject of separate PRs.

## How it was tested

Two YUR/DEL locks on firmware 2.1.6 / 2.1.0, driven from a live Home Assistant install running @pantherman594's fork of the yalexs_ble component. The two-timer runs set the timers to different values and watched each fire on its own trigger, with relock timings taken from the lock's own door and lock sensor reports. The reworked read and write paths were then field-checked on production: fresh-session reads populated both locks' values from their BB 04 responses, a write of a new duration was confirmed on its BB 03 response with the entity following, an app-set value read back on the first cycle after connect, and the values survived every subsequent poll of the session with no reversion.

## Relation to other work**

- Supersedes #333: the byte it reports as an unrecognised mode is the door-close timer's low byte, so with this decode that path no longer exists.
- The auto-lock API arrived with #233, whose select-entity fork uses it today, and home-assistant/core#174331 adds core entities on the same calls, so both directions want to be correct before that reaches users.
- Independent of the jam-detection work (#355): different frames, different paths, touching only adjacent test code.