### PR TITLE
chore: ignore ruff rule PLR0917

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ ignore = [
     "PLR0912", # too many to fix right now
     "TID252", # skip
     "PLR0913", # too late to make changes here
+    "PLR0917", # too late to make changes here
     "PLR0911", # would be breaking change
     "TRY003", # too many to fix
     "SLF001", # design choice


### PR DESCRIPTION
The pre-commit autoupdate in #365 bumps ruff to 0.16.1, which now flags PLR0917 on Lock.__init__ and PushLock.__init__. Both are public API and Home Assistant passes these arguments positionally, so making them keyword only would be a breaking change; ignore the rule globally, same as the existing PLR0913 ignore.