### PR TITLE
fix: admission - check input from the radio before parsing it

### DIFF
--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -16,6 +16,12 @@ YALE_MFR_ID = 465
 HAP_FIRST_BYTE = 0x06
 HAP_ENCRYPTED_FIRST_BYTE = 0x11
 
+# Every frame on the link, sent or received, is 18 bytes: a 16-byte encrypted
+# block plus two trailing plain bytes, and the checksums run over all 18. The
+# command builders, the checksum helpers, and the notify admission gate all
+# share this length.
+RESPONSE_FRAME_LEN = 0x12
+
 
 MANUFACTURER_NAME_CHARACTERISTIC = "00002a29-0000-1000-8000-00805f9b34fb"
 MODEL_NUMBER_CHARACTERISTIC = "00002a24-0000-1000-8000-00805f9b34fb"

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -385,7 +385,11 @@ class Lock:
                             .decode()
                             .split("\0")[0]
                         )
-                    except BleakError as err:
+                    # The read is radio input too: the BLE controller bug
+                    # noted above corrupts packets, so the bytes may not be
+                    # UTF-8. A bad read degrades to the fallback for that
+                    # characteristic, like a failed one.
+                    except (BleakError, UnicodeDecodeError) as err:
                         _LOGGER.warning(
                             "%s: Failed to read characteristic %s: %s",
                             self.name,

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -1290,8 +1290,9 @@ class PushLock:
         mfr_data = ad.manufacturer_data
         # An empty payload is skipped rather than indexed: the advertisement is
         # radio input and its length is not ours to assume. Each refusal is
-        # logged at debug so a chronically truncated advertiser stays
-        # diagnosable instead of merely inert.
+        # logged at debug — not INFO like the notify gate — because
+        # advertisements repeat every few seconds, so a chronic condition
+        # would flood any stronger level; debug keeps it diagnosable.
         if apple_data := mfr_data.get(APPLE_MFR_ID):
             first_byte = apple_data[0]
             if first_byte == HAP_FIRST_BYTE:

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -1289,27 +1289,40 @@ class PushLock:
         next_update = 0.0
         mfr_data = ad.manufacturer_data
         # An empty payload is skipped rather than indexed: the advertisement is
-        # radio input and its length is not ours to assume.
+        # radio input and its length is not ours to assume. Each refusal is
+        # logged at debug so a chronically truncated advertiser stays
+        # diagnosable instead of merely inert.
         if apple_data := mfr_data.get(APPLE_MFR_ID):
             first_byte = apple_data[0]
-            if first_byte == HAP_FIRST_BYTE and (
-                (hk_state := get_homekit_state_num(apple_data)) is not None
-            ):
-                # Sometimes the yale data is glued on to the end of the HomeKit data
-                # but in that case it seems wrong so we don't process it
-                #
-                # if len(mfr_data[APPLE_MFR_ID]) > 20 and YALE_MFR_ID not in mfr_data:
-                # mfr_data[YALE_MFR_ID] = mfr_data[APPLE_MFR_ID][20:]
-                if self._last_hk_state == -1:
-                    # We haven't seen a HomeKit state yet so we schedule an update
-                    next_update = FIRST_UPDATE_COALESCE_SECONDS
-                elif hk_state != self._last_hk_state:
-                    next_update = HK_UPDATE_COALESCE_SECONDS
-                self._last_hk_state = hk_state
+            if first_byte == HAP_FIRST_BYTE:
+                if (hk_state := get_homekit_state_num(apple_data)) is None:
+                    _LOGGER.debug(
+                        "%s: %d-byte HomeKit advertisement ends before its"
+                        " state record; skipped",
+                        self.name,
+                        len(apple_data),
+                    )
+                else:
+                    # Sometimes the yale data is glued on to the end of the
+                    # HomeKit data but in that case it seems wrong so we
+                    # don't process it
+                    #
+                    # if len(mfr_data[APPLE_MFR_ID]) > 20
+                    #     and YALE_MFR_ID not in mfr_data:
+                    # mfr_data[YALE_MFR_ID] = mfr_data[APPLE_MFR_ID][20:]
+                    if self._last_hk_state == -1:
+                        # We haven't seen a HomeKit state yet so we schedule
+                        # an update
+                        next_update = FIRST_UPDATE_COALESCE_SECONDS
+                    elif hk_state != self._last_hk_state:
+                        next_update = HK_UPDATE_COALESCE_SECONDS
+                    self._last_hk_state = hk_state
             elif first_byte == HAP_ENCRYPTED_FIRST_BYTE:
                 # Encrypted data, we don't know how to decrypt it
                 # but we know its a state change so we schedule an update
                 next_update = HK_UPDATE_COALESCE_SECONDS
+        elif APPLE_MFR_ID in mfr_data:
+            _LOGGER.debug("%s: Empty HomeKit advertisement payload; skipped", self.name)
         # Yale YALE_MFR_ID advertisements come in two formats:
         # - 1-byte: lock state toggle (0/1), used for change detection
         # - 18-byte: 2 header bytes + the lock's 16-byte cloud ID (the
@@ -1335,6 +1348,8 @@ class PushLock:
                 ):
                     next_update = ADV_UPDATE_COALESCE_SECONDS
             self._last_adv_value = current_value
+        elif YALE_MFR_ID in mfr_data and not mfr_data[YALE_MFR_ID]:
+            _LOGGER.debug("%s: Empty Yale advertisement payload; skipped", self.name)
         if adv_debug_enabled:
             scheduled_update = None
             if self._cancel_deferred_update:

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -115,12 +115,6 @@ RETRYABLE_EXCEPTIONS = (*RETRY_BACKOFF_EXCEPTIONS, *RETRY_EXCEPTIONS)
 # there is no update from the lock.
 VALID_ADV_VALUES = {0, 1}
 
-# The HomeKit advertisement fields read below end at byte 15: the global state
-# number sits at [11:13] inside the <HHBB record that starts at byte 9. A
-# payload shorter than this carries no state number to read, so it is skipped
-# rather than unpacked.
-HAP_STATE_RECORD_END = 15
-
 AUTH_FAILURE_TO_START_REAUTH = 5
 
 # How long to wait before retrying battery after a timeout (5 minutes)
@@ -1298,8 +1292,9 @@ class PushLock:
         # radio input and its length is not ours to assume.
         if apple_data := mfr_data.get(APPLE_MFR_ID):
             first_byte = apple_data[0]
-            if first_byte == HAP_FIRST_BYTE and len(apple_data) >= HAP_STATE_RECORD_END:
-                hk_state = get_homekit_state_num(apple_data)
+            if first_byte == HAP_FIRST_BYTE and (
+                (hk_state := get_homekit_state_num(apple_data)) is not None
+            ):
                 # Sometimes the yale data is glued on to the end of the HomeKit data
                 # but in that case it seems wrong so we don't process it
                 #
@@ -1536,7 +1531,19 @@ class PushLock:
             _LOGGER.exception("%s: Unknown error updating", self.name)
 
 
-def get_homekit_state_num(data: bytes) -> int:
-    """Get the homekit state number from the manufacturer data."""
-    _acid, gsn, _cn, _cv = struct.unpack("<HHBB", data[9:15])
+# The HomeKit state record inside the advertisement payload: acid, the global
+# state number, cn, cv, starting at byte 9.
+_HAP_STATE_RECORD = struct.Struct("<HHBB")
+_HAP_STATE_RECORD_OFFSET = 9
+
+
+def get_homekit_state_num(data: bytes) -> int | None:
+    """Get the homekit state number from the manufacturer data.
+
+    Returns None when the payload ends before the record does: the
+    advertisement is radio input and its length is not ours to assume.
+    """
+    if len(data) < _HAP_STATE_RECORD_OFFSET + _HAP_STATE_RECORD.size:
+        return None
+    _acid, gsn, _cn, _cv = _HAP_STATE_RECORD.unpack_from(data, _HAP_STATE_RECORD_OFFSET)
     return gsn

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -115,6 +115,12 @@ RETRYABLE_EXCEPTIONS = (*RETRY_BACKOFF_EXCEPTIONS, *RETRY_EXCEPTIONS)
 # there is no update from the lock.
 VALID_ADV_VALUES = {0, 1}
 
+# The HomeKit advertisement fields read below end at byte 15: the global state
+# number sits at [11:13] inside the <HHBB record that starts at byte 9. A
+# payload shorter than this carries no state number to read, so it is skipped
+# rather than unpacked.
+HAP_STATE_RECORD_END = 15
+
 AUTH_FAILURE_TO_START_REAUTH = 5
 
 # How long to wait before retrying battery after a timeout (5 minutes)
@@ -1288,10 +1294,12 @@ class PushLock:
         self.set_advertisement_data(ad)
         next_update = 0.0
         mfr_data = ad.manufacturer_data
-        if APPLE_MFR_ID in mfr_data:
-            first_byte = mfr_data[APPLE_MFR_ID][0]
-            if first_byte == HAP_FIRST_BYTE:
-                hk_state = get_homekit_state_num(mfr_data[APPLE_MFR_ID])
+        # An empty payload is skipped rather than indexed: the advertisement is
+        # radio input and its length is not ours to assume.
+        if apple_data := mfr_data.get(APPLE_MFR_ID):
+            first_byte = apple_data[0]
+            if first_byte == HAP_FIRST_BYTE and len(apple_data) >= HAP_STATE_RECORD_END:
+                hk_state = get_homekit_state_num(apple_data)
                 # Sometimes the yale data is glued on to the end of the HomeKit data
                 # but in that case it seems wrong so we don't process it
                 #
@@ -1317,10 +1325,11 @@ class PushLock:
         # static 0x00 header of the 18-byte format causes repeated
         # connections if it differs from the 1-byte value.
         is_first_advertisement = self._last_adv_value == -1
-        if YALE_MFR_ID in mfr_data and (
-            len(mfr_data[YALE_MFR_ID]) == 1 or is_first_advertisement
+        # As above, an empty payload is skipped rather than indexed.
+        if (yale_data := mfr_data.get(YALE_MFR_ID)) and (
+            len(yale_data) == 1 or is_first_advertisement
         ):
-            current_value = mfr_data[YALE_MFR_ID][0]
+            current_value = yale_data[0]
             if not next_update:
                 if is_first_advertisement:
                     # We haven't seen a valid value yet so we schedule an update

--- a/src/yalexs_ble/secure_session.py
+++ b/src/yalexs_ble/secure_session.py
@@ -7,7 +7,11 @@ from bleak import BleakClient
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from . import util
-from .const import SECURE_READ_CHARACTERISTIC, SECURE_WRITE_CHARACTERISTIC
+from .const import (
+    RESPONSE_FRAME_LEN,
+    SECURE_READ_CHARACTERISTIC,
+    SECURE_WRITE_CHARACTERISTIC,
+)
 from .session import ResponseError, Session
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,7 +47,7 @@ class SecureSession(Session):
         ).decryptor()
 
     def build_command(self, opcode: int) -> bytearray:
-        cmd = bytearray(0x12)
+        cmd = bytearray(RESPONSE_FRAME_LEN)
         cmd[0x00] = opcode
         cmd[0x10] = 0x0F
         cmd[0x11] = self.key_index

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -275,11 +275,12 @@ class Session:
             "%s: Encrypted command %s: %s", self.name, command_name, command.hex()
         )
 
+        future: asyncio.Future[bytes] | None = None
         try:
             # The loop never exhausts: the last attempt re-raises, so the only
             # ways out are break and raise.
             for attempt in range(3):  # pragma: no branch
-                future: asyncio.Future[bytes] = self.loop.create_future()
+                future = self.loop.create_future()
                 self._notify_future = future
                 self._notify_matcher = response_matcher
                 _LOGGER.debug(
@@ -313,9 +314,15 @@ class Session:
             # the future is never awaited. Retrieve it so asyncio does not
             # log "exception was never retrieved" with no context. suppress
             # covers the pending and cancelled states, where there is
-            # nothing to retrieve.
-            with contextlib.suppress(asyncio.CancelledError, asyncio.InvalidStateError):
-                future.exception()
+            # nothing to retrieve. The None check guards only create_future
+            # itself raising on the first attempt, which would otherwise turn
+            # into a NameError here that masks the real error; no test can
+            # reach it.
+            if future is not None:  # pragma: no branch
+                with contextlib.suppress(
+                    asyncio.CancelledError, asyncio.InvalidStateError
+                ):
+                    future.exception()
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
         return result
 

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -16,21 +16,11 @@ from cryptography.hazmat.primitives.ciphers import (
 )
 
 from . import util
-from .const import READ_CHARACTERISTIC, WRITE_CHARACTERISTIC
+from .const import READ_CHARACTERISTIC, RESPONSE_FRAME_LEN, WRITE_CHARACTERISTIC
 
 _LOGGER = logging.getLogger(__name__)
 
 COOLDOWN_TIME = 0.25
-
-# Every frame the lock sends is 18 bytes: a 16-byte encrypted block plus two
-# trailing plain bytes, and the checksum runs over all 18. The gate is strict
-# equality, not a floor. A shorter payload must not reach the cipher: the
-# cipher context consumes ciphertext in 16-byte blocks, so a partial block
-# stays buffered inside it and every later frame on the connection decrypts
-# misaligned, a state only a reconnect's set_key rebuilds. A longer payload
-# would otherwise validate on its first 18 bytes and be passed on with a tail
-# the cipher never saw.
-RESPONSE_FRAME_LEN = 0x12
 
 
 class YaleXSBLEError(Exception):
@@ -122,7 +112,7 @@ class Session:
         return cmd
 
     def build_command(self, opcode: int) -> bytearray:
-        cmd = bytearray(0x12)
+        cmd = bytearray(RESPONSE_FRAME_LEN)
         cmd[0x00] = 0xEE
         cmd[0x01] = opcode
         cmd[0x10] = 0x02
@@ -133,13 +123,14 @@ class Session:
         command[0x03] = checksum
 
     def _validate_response(self, response: bytes | bytearray) -> None:
-        _LOGGER.debug(
-            "%s: Response simple checksum: %s",
-            self.name,
-            str(util._simple_checksum(response)),
-        )
-        if util._simple_checksum(response) != 0:
-            raise ResponseError(f"Simple checksum mismatch {response!r}")
+        checksum = util._simple_checksum(response)
+        _LOGGER.debug("%s: Response simple checksum: %s", self.name, checksum)
+        if checksum != 0:
+            # The frame itself is not repeated here: the drop line that logs
+            # this error already carries its hex.
+            raise ResponseError(
+                f"Simple checksum mismatch (expected 0, got {checksum})"
+            )
 
         if response[0x00] != 0xBB and response[0x00] != 0xAA:
             raise ResponseError(f"Incorrect flag in response: {response[0x00]}")
@@ -153,6 +144,18 @@ class Session:
         """Write under the lock."""
         async with self._lock:
             return await self._locked_write(command, command_name, response_matcher)
+
+    def _disarm_wait(self) -> asyncio.Future[bytes] | None:
+        """Disarm the solicited wait and return its future, if one was armed.
+
+        A caller that resolves the returned future must check done() first: a
+        timeout or a disconnect cancels the future from the waiting side, and
+        a frame that raced that cancellation must not resolve it again.
+        """
+        future = self._notify_future
+        self._notify_future = None
+        self._notify_matcher = None
+        return future
 
     def _reject_frame(
         self,
@@ -173,12 +176,8 @@ class Session:
         _LOGGER.log(
             level, "%s: dropping invalid frame %s: %s", self.name, frame.hex(), ex
         )
-        if self._notify_future is None:
-            return
-        _LOGGER.debug("%s: Invalid response, waiting for next one", self.name)
-        self._notify_future.set_exception(ex)
-        self._notify_future = None
-        self._notify_matcher = None
+        if (future := self._disarm_wait()) is not None and not future.done():
+            future.set_exception(ex)
 
     def _notify(self, char: int, data: bytearray) -> None:
         self._last_callback_time = time.monotonic()
@@ -188,21 +187,35 @@ class Session:
             data.hex(),
             bool(self._notify_future),
         )
+        if not data:
+            # An empty notification carries nothing to decrypt or judge, and
+            # it must not fail an armed wait: the real response is still in
+            # flight, and failing the wait would re-send the command while it
+            # is, so the lock would decrypt the duplicate as garbage. Drop it
+            # without touching the wait.
+            _LOGGER.debug("%s: Dropping empty notification", self.name)
+            return
         if len(data) != RESPONSE_FRAME_LEN:
-            # This gate must sit ahead of decrypt (see RESPONSE_FRAME_LEN):
-            # dropping the payload here keeps the cipher aligned, so the
-            # session stays usable for the next good frame.
+            # Strict equality, and it must sit ahead of decrypt: the cipher
+            # context consumes ciphertext in 16-byte blocks, so a partial
+            # block fed to it stays buffered inside and desynchronizes every
+            # later frame on the connection, a state only a reconnect's
+            # set_key rebuilds. An over-length payload would validate on its
+            # first 18 bytes and be passed on with a tail the cipher never
+            # saw. (Dropping a truncation of genuine ciphertext still skips a
+            # block the lock chained, so the next frame decrypts garbled and
+            # is rejected too; the chain recovers on the frame after, where a
+            # poisoned context never does.)
             self._reject_frame(
                 ResponseError(
                     f"{len(data)}-byte payload is not an "
                     f"{RESPONSE_FRAME_LEN}-byte response frame"
                 ),
                 data,
-                # A short payload is a corrupt frame off the air, which the
-                # radio produces on its own. An over-length one is not: the
-                # lock builds nothing longer, so it says the transport below
-                # is doing something nobody has seen, and it is worth a level
-                # more attention.
+                # An over-length frame is worth more attention than a short
+                # one: the radio truncates frames on its own, but nothing on
+                # the link builds a longer one, so it points at the transport
+                # below.
                 logging.WARNING if len(data) > RESPONSE_FRAME_LEN else logging.INFO,
             )
             return
@@ -234,9 +247,8 @@ class Session:
                 self.name,
             )
             return
-        self._notify_future.set_result(decrypted_data)
-        self._notify_future = None
-        self._notify_matcher = None
+        if (future := self._disarm_wait()) is not None and not future.done():
+            future.set_result(decrypted_data)
 
     async def _locked_write(
         self,
@@ -258,18 +270,18 @@ class Session:
             "%s: Encrypted command %s: %s", self.name, command_name, command.hex()
         )
 
-        for attempt in range(3):
-            future: asyncio.Future[bytes] = self.loop.create_future()
-            self._notify_future = future
-            self._notify_matcher = response_matcher
-            _LOGGER.debug(
-                "%s: Writing command to %s: %s",
-                self.name,
-                self.write_characteristic,
-                command.hex(),
-            )
-            _LOGGER.debug("%s: Waiting for response", self.name)
-            try:
+        try:
+            for attempt in range(3):
+                future: asyncio.Future[bytes] = self.loop.create_future()
+                self._notify_future = future
+                self._notify_matcher = response_matcher
+                _LOGGER.debug(
+                    "%s: Writing command to %s: %s",
+                    self.name,
+                    self.write_characteristic,
+                    command.hex(),
+                )
+                _LOGGER.debug("%s: Waiting for response", self.name)
                 async with util.asyncio_timeout(10):
                     try:
                         await self.client.write_gatt_char(
@@ -283,13 +295,12 @@ class Session:
                         continue
                     else:
                         break
-            except TimeoutError:
-                # The wait expired with the future still armed. Disarm it so a
-                # late frame cannot land on the cancelled future or leak this
-                # command's matcher into a later wait.
-                self._notify_future = None
-                self._notify_matcher = None
-                raise
+        finally:
+            # A timeout or a disconnect interrupt leaves the wait armed with a
+            # future the waiter has abandoned. Disarm it so a late frame
+            # cannot leak this command's matcher into a later wait. (On the
+            # paths that resolved the wait this is a no-op.)
+            self._disarm_wait()
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
         return result
 

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from collections.abc import Callable
@@ -126,10 +127,12 @@ class Session:
         checksum = util._simple_checksum(response)
         _LOGGER.debug("%s: Response simple checksum: %s", self.name, checksum)
         if checksum != 0:
-            # The frame itself is not repeated here: the drop line that logs
-            # this error already carries its hex.
+            # The frame hex rides on the error, not only on the drop line:
+            # when a command exhausts its attempts this error surfaces at
+            # levels where the INFO drop line was never emitted.
             raise ResponseError(
-                f"Simple checksum mismatch (expected 0, got {checksum})"
+                f"Simple checksum mismatch (expected 0, got {checksum}) "
+                f"in frame {response.hex()}"
             )
 
         if response[0x00] != 0xBB and response[0x00] != 0xAA:
@@ -303,6 +306,14 @@ class Session:
             # cannot leak this command's matcher into a later wait. (On the
             # paths that resolved the wait this is a no-op.)
             self._disarm_wait()
+            # A frame can fail the wait while the GATT write itself is still
+            # in flight; if the write then raises, the ResponseError set on
+            # the future is never awaited. Retrieve it so asyncio does not
+            # log "exception was never retrieved" with no context. suppress
+            # covers the pending and cancelled states, where there is
+            # nothing to retrieve.
+            with contextlib.suppress(asyncio.CancelledError, asyncio.InvalidStateError):
+                future.exception()
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
         return result
 

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -191,11 +191,13 @@ class Session:
             bool(self._notify_future),
         )
         if not data:
-            # An empty notification carries nothing to decrypt or judge, and
-            # it must not fail an armed wait: the real response is still in
-            # flight, and failing the wait would re-send the command while it
-            # is, so the lock would decrypt the duplicate as garbage. Drop it
-            # without touching the wait.
+            # An empty notification is a transport artifact, not a frame off
+            # the lock: the stack emits them on its own, so one carries no
+            # signal about the link or the command in flight, and it was a
+            # no-op here before the length gate existed. A truncated frame is
+            # different — it is evidence the response itself was corrupted —
+            # so it fails the armed wait below and triggers a re-send, while
+            # this is dropped without touching the wait.
             _LOGGER.debug("%s: Dropping empty notification", self.name)
             return
         if len(data) != RESPONSE_FRAME_LEN:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -271,7 +271,9 @@ class Session:
         )
 
         try:
-            for attempt in range(3):
+            # The loop never exhausts: the last attempt re-raises, so the only
+            # ways out are break and raise.
+            for attempt in range(3):  # pragma: no branch
                 future: asyncio.Future[bytes] = self.loop.create_future()
                 self._notify_future = future
                 self._notify_matcher = response_matcher

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -22,6 +22,16 @@ _LOGGER = logging.getLogger(__name__)
 
 COOLDOWN_TIME = 0.25
 
+# Every frame the lock sends is 18 bytes: a 16-byte encrypted block plus two
+# trailing plain bytes, and the checksum runs over all 18. The gate is strict
+# equality, not a floor. A shorter payload must not reach the cipher: the
+# cipher context consumes ciphertext in 16-byte blocks, so a partial block
+# stays buffered inside it and every later frame on the connection decrypts
+# misaligned, a state only a reconnect's set_key rebuilds. A longer payload
+# would otherwise validate on its first 18 bytes and be passed on with a tail
+# the cipher never saw.
+RESPONSE_FRAME_LEN = 0x12
+
 
 class YaleXSBLEError(Exception):
     """Base class for YaleXSBLE errors."""
@@ -144,6 +154,32 @@ class Session:
         async with self._lock:
             return await self._locked_write(command, command_name, response_matcher)
 
+    def _reject_frame(
+        self,
+        ex: ResponseError,
+        frame: bytes | bytearray,
+        level: int = logging.INFO,
+    ) -> None:
+        """Dispose of a frame that failed admission.
+
+        The frame is withheld from the state callback. A solicited wait still
+        receives the error, so _locked_write re-sends its command until its
+        attempts run out and it raises; an unsolicited frame has no waiter and
+        is dropped.
+        """
+        # The drop line carries the frame hex: these frames should not occur at
+        # all, so a drop and its evidence are visible without turning debug on,
+        # where the frames themselves are logged.
+        _LOGGER.log(
+            level, "%s: dropping invalid frame %s: %s", self.name, frame.hex(), ex
+        )
+        if self._notify_future is None:
+            return
+        _LOGGER.debug("%s: Invalid response, waiting for next one", self.name)
+        self._notify_future.set_exception(ex)
+        self._notify_future = None
+        self._notify_matcher = None
+
     def _notify(self, char: int, data: bytearray) -> None:
         self._last_callback_time = time.monotonic()
         _LOGGER.debug(
@@ -152,21 +188,39 @@ class Session:
             data.hex(),
             bool(self._notify_future),
         )
+        if len(data) != RESPONSE_FRAME_LEN:
+            # This gate must sit ahead of decrypt (see RESPONSE_FRAME_LEN):
+            # dropping the payload here keeps the cipher aligned, so the
+            # session stays usable for the next good frame.
+            self._reject_frame(
+                ResponseError(
+                    f"{len(data)}-byte payload is not an "
+                    f"{RESPONSE_FRAME_LEN}-byte response frame"
+                ),
+                data,
+                # A short payload is a corrupt frame off the air, which the
+                # radio produces on its own. An over-length one is not: the
+                # lock builds nothing longer, so it says the transport below
+                # is doing something nobody has seen, and it is worth a level
+                # more attention.
+                logging.WARNING if len(data) > RESPONSE_FRAME_LEN else logging.INFO,
+            )
+            return
         decrypted_data = self.decrypt(data)
-        if self._state_callback:
-            self._state_callback(decrypted_data)
         _LOGGER.debug(
             "%s: Decrypted response via notify: %s", self.name, decrypted_data.hex()
         )
-        if self._notify_future is None:
-            return
         try:
-            self._validate_response(data)
+            # Runs on every frame, not only while a wait is armed: the state
+            # callback below drives the consumer's state, so an unsolicited
+            # frame has to clear the same bar as a solicited one.
+            self._validate_response(decrypted_data)
         except ResponseError as ex:
-            _LOGGER.debug("%s: Invalid response, waiting for next one", self.name)
-            self._notify_future.set_exception(ex)
-            self._notify_future = None
-            self._notify_matcher = None
+            self._reject_frame(ex, decrypted_data)
+            return
+        if self._state_callback:
+            self._state_callback(decrypted_data)
+        if self._notify_future is None:
             return
         if self._notify_matcher is not None and not self._notify_matcher(
             decrypted_data

--- a/src/yalexs_ble/util.py
+++ b/src/yalexs_ble/util.py
@@ -12,11 +12,19 @@ from .const import RESPONSE_FRAME_LEN
 UNIQUE_LOCAL_NAME_LEN = 7
 
 
-def _simple_checksum(buf: bytes | bytearray) -> int:
-    # The helper defends its own input rather than lean on the notify gate:
-    # a slice over a short buffer would silently checksum whatever is there.
+def _require_frame_length(buf: bytes | bytearray) -> None:
+    """Refuse a buffer shorter than the frame a checksum runs over.
+
+    The checksum helpers defend their own input rather than lean on the
+    notify gate: a slice over a short buffer would silently checksum
+    whatever bytes are there.
+    """
     if len(buf) < RESPONSE_FRAME_LEN:
         raise ValueError(f"checksum needs {RESPONSE_FRAME_LEN} bytes, got {len(buf)}")
+
+
+def _simple_checksum(buf: bytes | bytearray) -> int:
+    _require_frame_length(buf)
     return (-sum(buf[:RESPONSE_FRAME_LEN])) & 0xFF
 
 
@@ -33,6 +41,7 @@ def _int_to_bytes(value: int, length: int) -> bytes:
 
 
 def _security_checksum(buffer: bytes | bytearray) -> int:
+    _require_frame_length(buffer)
     val1 = _bytes_to_int(buffer[0x00:0x04])
     val2 = _bytes_to_int(buffer[0x04:0x08])
     val3 = _bytes_to_int(buffer[0x08:RESPONSE_FRAME_LEN])

--- a/src/yalexs_ble/util.py
+++ b/src/yalexs_ble/util.py
@@ -7,15 +7,13 @@ from bleak import BleakError
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
+from .const import RESPONSE_FRAME_LEN
+
 UNIQUE_LOCAL_NAME_LEN = 7
 
 
 def _simple_checksum(buf: bytes | bytearray) -> int:
-    cs = 0
-    for i in range(0x12):
-        cs = (cs + buf[i]) & 0xFF
-
-    return (-cs) & 0xFF
+    return (-sum(buf[:RESPONSE_FRAME_LEN])) & 0xFF
 
 
 def _bytes_to_int(buffer: bytes | bytearray) -> int:
@@ -33,7 +31,7 @@ def _int_to_bytes(value: int, length: int) -> bytes:
 def _security_checksum(buffer: bytes | bytearray) -> int:
     val1 = _bytes_to_int(buffer[0x00:0x04])
     val2 = _bytes_to_int(buffer[0x04:0x08])
-    val3 = _bytes_to_int(buffer[0x08:0x12])
+    val3 = _bytes_to_int(buffer[0x08:RESPONSE_FRAME_LEN])
 
     return (0 - (val1 + val2 + val3)) & 0xFFFFFFFF
 

--- a/src/yalexs_ble/util.py
+++ b/src/yalexs_ble/util.py
@@ -13,6 +13,10 @@ UNIQUE_LOCAL_NAME_LEN = 7
 
 
 def _simple_checksum(buf: bytes | bytearray) -> int:
+    # The helper defends its own input rather than lean on the notify gate:
+    # a slice over a short buffer would silently checksum whatever is there.
+    if len(buf) < RESPONSE_FRAME_LEN:
+        raise ValueError(f"checksum needs {RESPONSE_FRAME_LEN} bytes, got {len(buf)}")
     return (-sum(buf[:RESPONSE_FRAME_LEN])) & 0xFF
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -618,6 +618,7 @@ _CHAR_ORDER: tuple[str, ...] = (
 
 def _make_lock_with_mock_client(
     side_effects: dict[str, Exception] | None = None,
+    data_overrides: dict[str, bytes] | None = None,
 ) -> tuple[Lock, MagicMock]:
     """Create a Lock with a mock BLE client for lock_info tests."""
     lock = Lock(
@@ -634,6 +635,7 @@ def _make_lock_with_mock_client(
     lock.secure_session = MagicMock()
 
     effects = side_effects or {}
+    overrides = data_overrides or {}
 
     # Map each characteristic UUID to a unique mock object so
     # read_gatt_char can identify which UUID is being read.
@@ -650,7 +652,7 @@ def _make_lock_with_mock_client(
         uuid = mock_to_uuid[id(char)]
         if uuid in effects:
             raise effects[uuid]
-        return _CHAR_DATA[uuid]
+        return overrides.get(uuid, _CHAR_DATA[uuid])
 
     mock_client.read_gatt_char = read_gatt_char
     mock_client._mock_to_uuid = mock_to_uuid
@@ -683,6 +685,27 @@ async def test_lock_info_partial_failure() -> None:
 
     assert info.manufacturer == "Yale/August"
     assert info.model == "ASL-03"
+    assert info.serial == "aa:bb:cc:dd:ee:ff"
+    assert info.firmware == "2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_lock_info_non_utf8_read_degrades_to_fallback() -> None:
+    """A corrupt read that is not UTF-8 degrades like a failed one.
+
+    The characteristic read is radio input too — the BLE controller bug
+    noted in lock_info corrupts packets — and decode() raises
+    UnicodeDecodeError, which is not a BleakError, so it used to escape the
+    handler and abort lock_info with the partial results discarded.
+    """
+    lock, _ = _make_lock_with_mock_client(
+        data_overrides={SERIAL_NUMBER_CHARACTERISTIC: b"\xff\xfe\xff"}
+    )
+
+    info = await lock.lock_info()
+
+    assert info.model == "ASL-03"
+    # The BLE address stands in for the unreadable serial.
     assert info.serial == "aa:bb:cc:dd:ee:ff"
     assert info.firmware == "2.0.0"
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import struct
 import time
 from collections.abc import Callable
 from typing import Any
@@ -23,6 +24,7 @@ from yalexs_ble.const import (
 from yalexs_ble.lock import Lock
 from yalexs_ble.push import (
     _AUTH_FAILURE_HISTORY,
+    APPLE_MFR_ID,
     AUTH_FAILURE_TO_START_REAUTH,
     AUTO_LOCK_READ_FAILURE_BACKOFF,
     AUTO_LOCK_READ_FAILURE_THRESHOLD,
@@ -31,6 +33,7 @@ from yalexs_ble.push import (
     AUTO_LOCK_WRITE_ATTEMPTS,
     BATTERY_REFRESH_INTERVAL,
     DEFAULT_ATTEMPTS,
+    HAP_FIRST_BYTE,
     NEVER_TIME,
     NO_BATTERY_SUPPORT_MODELS,
     SLOW_LATENCY,
@@ -2181,3 +2184,77 @@ async def test_set_auto_lock_write_retries_twice_then_gives_up(
         await push_lock._set_auto_lock(AutoLockMode.TIMER, 30)
 
     assert mock_lock.set_auto_lock.await_count == AUTO_LOCK_WRITE_ATTEMPTS
+
+
+def _advertisement(manufacturer_data: dict[int, bytes]) -> AdvertisementData:
+    """An advertisement carrying the given manufacturer payloads."""
+    return AdvertisementData(
+        local_name="Test Lock",
+        service_data={},
+        service_uuids=[],
+        rssi=-50,
+        manufacturer_data=manufacturer_data,
+        platform_data=(),
+        tx_power=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "manufacturer_data",
+    [
+        # A HomeKit payload that ends before the state number it advertises.
+        {APPLE_MFR_ID: bytes([HAP_FIRST_BYTE]) + b"\x00" * 8},
+        # One byte short of the state record, which is the boundary the guard
+        # turns on: at 14 bytes the unpack still runs off the end.
+        {APPLE_MFR_ID: bytes([HAP_FIRST_BYTE]) + b"\x00" * 13},
+        # An empty payload under either identifier.
+        {APPLE_MFR_ID: b""},
+        {YALE_MFR_ID: b""},
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_short_advertisement_payload_is_skipped_not_parsed(
+    manufacturer_data: dict[int, bytes],
+) -> None:
+    """A payload too short for the fields read from it schedules nothing.
+
+    An advertisement is radio input and its length is not ours to assume. The
+    parse used to index and unpack it unconditionally, so a truncated payload
+    raised out of the callback the consumer dispatches from.
+    """
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:28",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    ble_device = BLEDevice(push_lock.address, "Test Lock", None)
+
+    push_lock.update_advertisement(ble_device, _advertisement(manufacturer_data))
+
+    assert push_lock._cancel_deferred_update is None
+    assert push_lock._last_hk_state == -1
+
+
+@pytest.mark.asyncio
+async def test_a_full_homekit_advertisement_still_reads_its_state_number() -> None:
+    """The guard admits a payload long enough for the fields it reads."""
+    push_lock = PushLock(
+        address="aa:bb:cc:dd:ee:29",
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=False,
+    )
+    push_lock._name = "Test Lock"
+    ble_device = BLEDevice(push_lock.address, "Test Lock", None)
+    # <HHBB at byte 9: acid, then the global state number 0x1234.
+    payload = (
+        bytes([HAP_FIRST_BYTE]) + b"\x00" * 8 + struct.pack("<HHBB", 1, 0x1234, 0, 0)
+    )
+
+    push_lock.update_advertisement(ble_device, _advertisement({APPLE_MFR_ID: payload}))
+
+    assert push_lock._last_hk_state == 0x1234
+    assert push_lock._cancel_deferred_update is not None
+    push_lock._cancel_future_update()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -2231,18 +2231,38 @@ async def test_a_short_advertisement_payload_is_skipped_not_parsed(
     assert push_lock._last_hk_state == -1
 
 
+def _hap_payload(state_num: int) -> bytes:
+    """A full HomeKit advertisement payload carrying the given state number."""
+    # <HHBB at byte 9: acid, then the global state number.
+    return (
+        bytes([HAP_FIRST_BYTE]) + b"\x00" * 8 + struct.pack("<HHBB", 1, state_num, 0, 0)
+    )
+
+
 @pytest.mark.asyncio
 async def test_a_full_homekit_advertisement_still_reads_its_state_number() -> None:
     """The guard admits a payload long enough for the fields it reads."""
     push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:29", always_connected=False)
     ble_device = BLEDevice(push_lock.address, "Test Lock", None)
-    # <HHBB at byte 9: acid, then the global state number 0x1234.
-    payload = (
-        bytes([HAP_FIRST_BYTE]) + b"\x00" * 8 + struct.pack("<HHBB", 1, 0x1234, 0, 0)
-    )
 
-    push_lock.update_advertisement(ble_device, _advertisement({APPLE_MFR_ID: payload}))
+    push_lock.update_advertisement(
+        ble_device, _advertisement({APPLE_MFR_ID: _hap_payload(0x1234)})
+    )
 
     assert push_lock._last_hk_state == 0x1234
     assert push_lock._cancel_deferred_update is not None
     push_lock._cancel_future_update()
+
+    # A changed state number schedules another update; a repeat does not.
+    push_lock.update_advertisement(
+        ble_device, _advertisement({APPLE_MFR_ID: _hap_payload(0x1235)})
+    )
+    assert push_lock._last_hk_state == 0x1235
+    assert push_lock._cancel_deferred_update is not None
+    push_lock._cancel_future_update()
+
+    push_lock.update_advertisement(
+        ble_device, _advertisement({APPLE_MFR_ID: _hap_payload(0x1235)})
+    )
+    assert push_lock._last_hk_state == 0x1235
+    assert push_lock._cancel_deferred_update is None

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1783,7 +1783,7 @@ async def test_set_auto_lock_write_resets_read_backoff() -> None:
 
 
 def _auto_lock_push_lock(address: str, *, always_connected: bool) -> PushLock:
-    """A named PushLock for the auto lock read outcome tests."""
+    """A named PushLock with the canonical test key and slot."""
     push_lock = PushLock(
         address=address,
         key="0800200c9a66",
@@ -2222,13 +2222,7 @@ async def test_a_short_advertisement_payload_is_skipped_not_parsed(
     parse used to index and unpack it unconditionally, so a truncated payload
     raised out of the callback the consumer dispatches from.
     """
-    push_lock = PushLock(
-        address="aa:bb:cc:dd:ee:28",
-        key="0800200c9a66",
-        key_index=1,
-        always_connected=False,
-    )
-    push_lock._name = "Test Lock"
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:28", always_connected=False)
     ble_device = BLEDevice(push_lock.address, "Test Lock", None)
 
     push_lock.update_advertisement(ble_device, _advertisement(manufacturer_data))
@@ -2240,13 +2234,7 @@ async def test_a_short_advertisement_payload_is_skipped_not_parsed(
 @pytest.mark.asyncio
 async def test_a_full_homekit_advertisement_still_reads_its_state_number() -> None:
     """The guard admits a payload long enough for the fields it reads."""
-    push_lock = PushLock(
-        address="aa:bb:cc:dd:ee:29",
-        key="0800200c9a66",
-        key_index=1,
-        always_connected=False,
-    )
-    push_lock._name = "Test Lock"
+    push_lock = _auto_lock_push_lock("aa:bb:cc:dd:ee:29", always_connected=False)
     ble_device = BLEDevice(push_lock.address, "Test Lock", None)
     # <HHBB at byte 9: acid, then the global state number 0x1234.
     payload = (

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,12 +23,18 @@ READ_ANSWER = bytes.fromhex("bb0400fb2800000008070807000000000000")
 CORRUPT_ANSWER = bytes.fromhex("bb0400002800000008070807000000000000")
 
 
-def _make_session(received: list[bytes]) -> Session:
-    """Create a Session with a mock client and pass-through crypto."""
+def _make_session(received: list[bytes], key: bytes | None = None) -> Session:
+    """Create a Session with a mock client.
+
+    Pass-through crypto by default; with ``key``, the real CBC contexts.
+    """
     client = MagicMock(is_connected=True)
     session = Session(client, "testlock", asyncio.Lock(), set(), received.append)
-    session.decrypt = bytes  # type: ignore[method-assign, assignment]
-    session.cipher_encrypt = MagicMock(update=bytes)
+    if key is None:
+        session.decrypt = bytes  # type: ignore[method-assign, assignment]
+        session.cipher_encrypt = MagicMock(update=bytes)
+    else:
+        session.set_key(key)
     return session
 
 
@@ -216,14 +222,6 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
 SESSION_KEY = bytes(range(16))
 
 
-def _make_encrypted_session(received: list[bytes]) -> Session:
-    """Create a Session with the real CBC contexts rather than pass-through."""
-    client = MagicMock(is_connected=True)
-    session = Session(client, "testlock", asyncio.Lock(), set(), received.append)
-    session.set_key(SESSION_KEY)
-    return session
-
-
 def _lock_side_frames(*plaintexts: bytes) -> list[bytes]:
     """Encrypt frames the way the lock does, as one chained stream.
 
@@ -245,7 +243,7 @@ async def test_a_short_frame_is_dropped_before_it_can_poison_the_cipher() -> Non
     frame after the runt must still decode.
     """
     received: list[bytes] = []
-    session = _make_encrypted_session(received)
+    session = _make_session(received, key=SESSION_KEY)
     first, second = _lock_side_frames(READ_ACK, READ_ANSWER)
 
     session._notify(0, bytearray(first))
@@ -307,40 +305,85 @@ async def test_a_short_frame_ends_an_armed_wait_and_the_command_is_re_sent() -> 
 
 
 @pytest.mark.asyncio
-async def test_an_over_length_frame_is_logged_a_level_above_a_short_one(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """An over-length payload names a transport fault, not a corrupt frame.
+async def test_an_empty_notification_leaves_an_armed_wait_armed() -> None:
+    """An empty payload is dropped without failing the wait.
 
-    Nothing on either side of the link builds a frame longer than the response
-    length, so an over-length one says the stack below is behaving in a way
-    nobody has seen. A short frame is ordinary radio corruption.
+    The real response is still in flight when the empty notification lands;
+    failing the wait would re-send the command while it is, and the lock
+    would decrypt the duplicate as garbage. The wait stays armed and the
+    real frame answers it, with no second write.
     """
     received: list[bytes] = []
     session = _make_session(received)
 
-    with caplog.at_level(logging.INFO, logger="yalexs_ble.session"):
-        session._notify(0, bytearray(READ_ANSWER + READ_ANSWER))
-        session._notify(0, bytearray(9))
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray())
+        # The empty payload must not have failed the wait.
+        assert session._notify_future is not None
+        session._notify(0, bytearray(READ_ANSWER))
 
-    drops = [r for r in caplog.records if "dropping invalid frame" in r.getMessage()]
-    assert [r.levelname for r in drops] == ["WARNING", "INFO"]
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(bytearray(18), "auto_lock_status")
+
+    assert result == READ_ANSWER
+    assert session.client.write_gatt_char.await_count == 1
+    assert received == [READ_ANSWER]
 
 
 @pytest.mark.asyncio
-async def test_the_frame_length_gate_is_strict_equality() -> None:
-    """A longer payload is refused as well as a shorter one.
+async def test_a_frame_racing_a_cancelled_wait_does_not_raise() -> None:
+    """A frame landing after the waiter gave up must not blow up the callback.
 
-    A frame carrying more than the response length would otherwise validate on
-    its first 18 bytes and be passed on with a tail the cipher never saw.
+    A timeout or a disconnect cancels the armed future from the waiting side,
+    and a notification already queued in that window then finds a future that
+    is done. Resolving it again would raise InvalidStateError out of the
+    notify callback; instead the wait is disarmed and the frame still takes
+    its normal path.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    def arm_cancelled_wait() -> None:
+        future: asyncio.Future[bytes] = session.loop.create_future()
+        session._notify_future = future
+        future.cancel()
+
+    # A valid frame against a cancelled wait: state still updates.
+    arm_cancelled_wait()
+    session._notify(0, bytearray(READ_ANSWER))
+    assert received == [READ_ANSWER]
+    assert session._notify_future is None
+
+    # An invalid frame against a cancelled wait: dropped, wait disarmed.
+    arm_cancelled_wait()
+    session._notify(0, bytearray(9))
+    assert received == [READ_ANSWER]
+    assert session._notify_future is None
+
+
+@pytest.mark.asyncio
+async def test_an_over_length_frame_is_refused_and_logged_a_level_above(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The length gate is strict equality, and over-length earns more noise.
+
+    A frame carrying more than the response length would otherwise validate
+    on its first 18 bytes and be passed on with a tail the cipher never saw,
+    so it is refused like a short one. It is also logged a level above: the
+    radio truncates frames on its own, but nothing on the link builds a
+    longer one, so over-length points at the transport below.
     """
     received: list[bytes] = []
     session = _make_session(received)
     assert len(READ_ANSWER) == RESPONSE_FRAME_LEN
 
-    session._notify(0, bytearray(READ_ANSWER + READ_ANSWER))
+    with caplog.at_level(logging.INFO, logger="yalexs_ble.session"):
+        session._notify(0, bytearray(READ_ANSWER + READ_ANSWER))
+        session._notify(0, bytearray(9))
 
     assert received == []
+    drops = [r for r in caplog.records if "dropping invalid frame" in r.getMessage()]
+    assert [r.levelname for r in drops] == ["WARNING", "INFO"]
 
 
 def _secure_on_air(frame: bytes | bytearray) -> bytes:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -267,8 +267,11 @@ async def test_a_rejection_during_a_failing_write_is_not_left_unretrieved() -> N
     """
     received: list[bytes] = []
     session = _make_session(received)
+    orphaned: list[asyncio.Future[bytes]] = []
 
     async def deliver(*_args: object, **_kwargs: object) -> None:
+        assert session._notify_future is not None
+        orphaned.append(session._notify_future)
         session._notify(0, bytearray(9))
         raise BleakError("write failed")
 
@@ -277,6 +280,13 @@ async def test_a_rejection_during_a_failing_write_is_not_left_unretrieved() -> N
         await session.execute(bytearray(18), "auto_lock_status")
 
     assert session._notify_future is None
+    # _log_traceback is the flag asyncio checks on GC to emit "exception was
+    # never retrieved"; set_exception raises it and only a retrieval clears
+    # it, so False here proves the finally block consumed the error. It must
+    # be read before exception() below, which would clear it itself.
+    (future,) = orphaned
+    assert future._log_traceback is False
+    assert isinstance(future.exception(), ResponseError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,14 +1,17 @@
-"""Session-level tests for the solicited-response matcher."""
+"""Session-level tests for frame admission and the solicited-response matcher."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from yalexs_ble import util
 from yalexs_ble.const import Commands, SettingType
 from yalexs_ble.lock import _settings_response_matcher
-from yalexs_ble.session import ResponseError, Session
+from yalexs_ble.secure_session import SecureSession
+from yalexs_ble.session import RESPONSE_FRAME_LEN, ResponseError, Session
 
 # Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
 # acknowledgment and, ~40 ms later, the 0xBB frame carrying the stored value
@@ -96,8 +99,9 @@ async def test_corrupt_frame_disarms_the_wait_and_the_command_is_retried() -> No
 
     assert result == READ_ANSWER
     assert session.client.write_gatt_char.await_count == 2
-    # Both frames reached the state callback; only the valid one answered.
-    assert received == [CORRUPT_ANSWER, READ_ANSWER]
+    # The corrupt frame was withheld from the state callback; only the valid
+    # one reached it, and only it answered.
+    assert received == [READ_ANSWER]
 
 
 @pytest.mark.asyncio
@@ -207,3 +211,170 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
 
     assert result == READ_ANSWER
     assert session._notify_future is None
+
+
+SESSION_KEY = bytes(range(16))
+
+
+def _make_encrypted_session(received: list[bytes]) -> Session:
+    """Create a Session with the real CBC contexts rather than pass-through."""
+    client = MagicMock(is_connected=True)
+    session = Session(client, "testlock", asyncio.Lock(), set(), received.append)
+    session.set_key(SESSION_KEY)
+    return session
+
+
+def _lock_side_frames(*plaintexts: bytes) -> list[bytes]:
+    """Encrypt frames the way the lock does, as one chained stream.
+
+    The first 16 bytes are one CBC block and the last two travel in the clear,
+    and the context chains across frames, which is why a frame that reaches
+    our decryptor out of step desynchronizes every frame after it.
+    """
+    encryptor = Cipher(algorithms.AES(SESSION_KEY), modes.CBC(bytes(0x10))).encryptor()
+    return [encryptor.update(p[0:0x10]) + p[0x10:0x12] for p in plaintexts]
+
+
+@pytest.mark.asyncio
+async def test_a_short_frame_is_dropped_before_it_can_poison_the_cipher() -> None:
+    """A wrong-length payload never reaches the cipher, so the stream survives.
+
+    The CBC context consumes ciphertext in 16-byte blocks. A partial block
+    would stay buffered inside it and every later frame on the connection
+    would decrypt misaligned, which only a reconnect's set_key could undo. The
+    frame after the runt must still decode.
+    """
+    received: list[bytes] = []
+    session = _make_encrypted_session(received)
+    first, second = _lock_side_frames(READ_ACK, READ_ANSWER)
+
+    session._notify(0, bytearray(first))
+    session._notify(0, bytearray(b"\x00" * 10))
+    session._notify(0, bytearray(second))
+
+    assert received == [READ_ACK, READ_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_an_unsolicited_invalid_frame_is_withheld_from_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A frame arriving with no wait armed is validated too, and dropped.
+
+    The state callback drives the consumer's state whether or not a command is
+    outstanding, so an unsolicited frame has to clear the same bar.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    short_frame = bytearray(9)
+
+    with caplog.at_level(logging.INFO, logger="yalexs_ble.session"):
+        session._notify(0, bytearray(CORRUPT_ANSWER))
+        session._notify(0, short_frame)
+
+    assert received == []
+    assert "dropping invalid frame" in caplog.text
+    assert "9-byte payload is not an 18-byte response frame" in caplog.text
+    # The drop line carries the frame itself, so a survey of the stream can
+    # still read what was refused.
+    assert CORRUPT_ANSWER.hex() in caplog.text
+    assert short_frame.hex() in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_short_frame_ends_an_armed_wait_and_the_command_is_re_sent() -> None:
+    """A wrong-length frame reaches the waiter instead of costing it a timeout.
+
+    The checksum helper indexes 18 bytes unconditionally, so before the gate a
+    short frame raised IndexError out of the callback with the wait still
+    armed, and the caller paid the whole response timeout before it could try
+    again. The gate ends the wait with a ResponseError, so the command goes
+    out again straight away.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    frames = [bytearray(9), bytearray(READ_ANSWER)]
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, frames.pop(0))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(bytearray(18), "auto_lock_status")
+
+    assert result == READ_ANSWER
+    assert session.client.write_gatt_char.await_count == 2
+    assert received == [READ_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_an_over_length_frame_is_logged_a_level_above_a_short_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An over-length payload names a transport fault, not a corrupt frame.
+
+    Nothing on either side of the link builds a frame longer than the response
+    length, so an over-length one says the stack below is behaving in a way
+    nobody has seen. A short frame is ordinary radio corruption.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    with caplog.at_level(logging.INFO, logger="yalexs_ble.session"):
+        session._notify(0, bytearray(READ_ANSWER + READ_ANSWER))
+        session._notify(0, bytearray(9))
+
+    drops = [r for r in caplog.records if "dropping invalid frame" in r.getMessage()]
+    assert [r.levelname for r in drops] == ["WARNING", "INFO"]
+
+
+@pytest.mark.asyncio
+async def test_the_frame_length_gate_is_strict_equality() -> None:
+    """A longer payload is refused as well as a shorter one.
+
+    A frame carrying more than the response length would otherwise validate on
+    its first 18 bytes and be passed on with a tail the cipher never saw.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    assert len(READ_ANSWER) == RESPONSE_FRAME_LEN
+
+    session._notify(0, bytearray(READ_ANSWER + READ_ANSWER))
+
+    assert received == []
+
+
+def _secure_on_air(frame: bytes | bytearray) -> bytes:
+    """Encrypt a frame the way the lock sends it on the secure channel.
+
+    The first 16 bytes are one ECB block and the last two travel in the clear,
+    which is the same shape as the plain channel with a different mode.
+    """
+    encryptor = Cipher(algorithms.AES(SESSION_KEY), modes.ECB()).encryptor()  # nosec
+    return encryptor.update(bytes(frame[0x00:0x10])) + bytes(frame[0x10:0x12])
+
+
+@pytest.mark.asyncio
+async def test_a_secure_session_handshake_frame_still_answers_its_wait() -> None:
+    """The authentication path shares _notify, so admission runs on it too.
+
+    SecureSession overrides the cipher mode and the checksum rule but not
+    _notify, so the length gate and the validation now ahead of the state
+    callback both run on the handshake. A handshake reply has to clear them,
+    and it carries no state callback to fall back on.
+    """
+    client = MagicMock(is_connected=True)
+    session = SecureSession(client, "testlock", asyncio.Lock(), set(), 1)
+    session.set_key(SESSION_KEY)
+    # The lock's reply to the key exchange, checksummed as the lock stamps it.
+    answer = session.build_command(0x02)
+    session._write_checksum(answer)
+    on_air = _secure_on_air(answer)
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(on_air))
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+
+    assert len(on_air) == RESPONSE_FRAME_LEN
+    result = await session.execute(session.build_command(0x01), "KEY_EXCHANGE")
+    assert result == bytes(answer)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -219,6 +219,24 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
     assert session._notify_future is None
 
 
+@pytest.mark.asyncio
+async def test_the_command_builders_emit_exactly_one_response_frame() -> None:
+    """Both builders and the admission gate share the one frame length.
+
+    The gate refuses anything that is not RESPONSE_FRAME_LEN bytes, so a
+    command builder drifting from it would emit frames the link itself
+    rejects.
+    """
+    session = _make_session([])
+    cmd = session.build_operation_command(0x0B, 0x05)
+
+    assert len(cmd) == RESPONSE_FRAME_LEN
+    assert cmd[0x00] == 0xEE
+    assert cmd[0x01] == 0x0B
+    assert cmd[0x04] == 0x05
+    assert cmd[0x10] == 0x02
+
+
 SESSION_KEY = bytes(range(16))
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -220,15 +221,38 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
     assert session._notify_future is None
 
 
-def test_the_simple_checksum_refuses_a_short_buffer() -> None:
-    """The checksum helper defends its own input.
+@pytest.mark.parametrize("checksum", [util._simple_checksum, util._security_checksum])
+def test_the_checksum_helpers_refuse_a_short_buffer(
+    checksum: Callable[[bytes], int],
+) -> None:
+    """Both checksum helpers defend their own input.
 
     A slice over a short buffer would silently checksum whatever bytes are
-    there — potentially summing to a "valid" 0 — so the helper raises
-    instead of leaning on the notify gate being its only caller.
+    there — potentially summing to a "valid" result — so the helpers raise
+    instead of leaning on the notify gate being their only caller.
     """
     with pytest.raises(ValueError, match="checksum needs 18 bytes, got 17"):
-        util._simple_checksum(b"\x00" * 17)
+        checksum(b"\x00" * 17)
+
+
+@pytest.mark.asyncio
+async def test_a_frame_with_an_unknown_flag_is_withheld_from_state() -> None:
+    """A valid checksum alone does not admit a frame with an unknown flag.
+
+    The flag check used to run only while a wait was armed; an unsolicited
+    frame carrying an opcode byte the protocol does not use is now withheld
+    from the state callback like any other admission failure.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+    frame = bytearray(RESPONSE_FRAME_LEN)
+    frame[0x00] = 0xCC
+    frame[0x03] = util._simple_checksum(frame)
+    assert util._simple_checksum(frame) == 0
+
+    session._notify(0, frame)
+
+    assert received == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from bleak import BleakError
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from yalexs_ble import util
@@ -216,6 +217,41 @@ async def test_fresh_command_rearms_slot_after_timeout() -> None:
     result = await session._locked_write(bytearray(18), "auto_lock_status")
 
     assert result == READ_ANSWER
+    assert session._notify_future is None
+
+
+def test_the_simple_checksum_refuses_a_short_buffer() -> None:
+    """The checksum helper defends its own input.
+
+    A slice over a short buffer would silently checksum whatever bytes are
+    there — potentially summing to a "valid" 0 — so the helper raises
+    instead of leaning on the notify gate being its only caller.
+    """
+    with pytest.raises(ValueError, match="checksum needs 18 bytes, got 17"):
+        util._simple_checksum(b"\x00" * 17)
+
+
+@pytest.mark.asyncio
+async def test_a_rejection_during_a_failing_write_is_not_left_unretrieved() -> None:
+    """A wait failed mid-write must not leak an unretrieved exception.
+
+    A frame can fail the wait while the GATT write itself is still in
+    flight; when the write then raises, nothing ever awaits the future the
+    ResponseError was set on. The write's own error still propagates, and
+    the finally block retrieves the orphaned exception so asyncio does not
+    log 'exception was never retrieved' later.
+    """
+    received: list[bytes] = []
+    session = _make_session(received)
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(9))
+        raise BleakError("write failed")
+
+    session.client.write_gatt_char = AsyncMock(side_effect=deliver)
+    with pytest.raises(BleakError, match="write failed"):
+        await session.execute(bytearray(18), "auto_lock_status")
+
     assert session._notify_future is None
 
 


### PR DESCRIPTION
### The problem

Notifications and advertisements are parsed before they are checked. Both are
callbacks: the data arrives unsolicited, so an exception escapes into the
dispatcher rather than reaching a caller.

`Session._notify` decrypts and publishes every notification ahead of any
validation: the state callback fires before the checksum, and the checksum
runs only while a solicited wait is armed. A wrong-length payload costs most:
a short one leaves a partial block buffered in the cipher context, so every
later frame decrypts misaligned until a reconnect rebuilds it.

`PushLock.update_advertisement` reads its manufacturer data without checking
the bytes are present, so a truncated payload raises. Neither path had a test
for a malformed payload.

### The change

Admission runs in receive order on both paths. A notification that is not the
response frame length is dropped before the cipher sees it, so the session
stays aligned and recovers on the next good frame, and one that clears the
gate meets the existing checksum and flag checks before the state callback
rather than after. An advertisement payload is skipped unless it carries the
fields being read from it, and each refusal is logged at debug so a
chronically truncated advertiser stays diagnosable.

One acceptance change rides on the reorder and is worth stating plainly: on
`main`, unsolicited frames were never checksum-validated — validation ran
only while a wait was armed. Now every push frame must clear the simple
checksum and the 0xAA/0xBB flag check to reach the state callback. The flag
half is free (the state parser already ignored other opcodes), but if any
firmware stamps its unsolicited frames' checksums differently from the
solicited responses this library has always validated, push updates from that
firmware stop, with one INFO drop line per frame as the evidence.

The empty payload is the one wrong-length case that does not fail an armed
wait: the real response is still in flight, and failing the wait would
re-send the command while it is, so the lock would decrypt the duplicate as
garbage. It is dropped without touching the wait.

The solicited contract holds: a wait still receives `ResponseError` and the
command is re-sent. A short frame comes off better than before, since it used
to raise `IndexError` out of the callback, leaving the wait armed and costing
the caller a full response timeout, and it now ends that wait at once. One
pre-existing caveat now has more traffic routed into it: the retry re-writes
the same already-encrypted bytes, which a real lock's chained decryptor
decodes as garbage, so a wrong-length frame burns the remaining attempts
where `main` paid a single timeout. Re-encrypting per attempt is a protocol
decision (it would turn the replay into a decodable duplicate command) and is
left out of this change. The
delivery itself is guarded: the wait is disarmed through one helper that
checks `done()` first, so a frame racing a timeout or disconnect cancellation
cannot raise `InvalidStateError` out of bleak's dispatch, and `_locked_write`
disarms on every exit path and retrieves an exception the write's own failure
orphaned. A dropped frame is logged with its hex — INFO for a short frame,
WARNING for an over-length one, since nothing on the link builds a longer
frame and that points at the transport below. The checksum rules, the
response matcher, and the retry loop semantics are untouched. The secure
session shares `_notify`, so its handshake frames clear the same gate, and
its own checksum rule is unchanged.

Two adjacent admission fixes travel with it: `lock_info` catches
`UnicodeDecodeError` alongside `BleakError`, so a corrupt characteristic read
degrades to the per-characteristic fallback instead of aborting the probe,
and both checksum helpers refuse a buffer shorter than the frame they
checksum rather than silently summing what is there. The 18-byte invariant now
lives in one place: `RESPONSE_FRAME_LEN` in `const.py`, shared by the gate,
both command builders, and both checksum helpers. The HomeKit record guard
lives inside `get_homekit_state_num`, derived from the struct it protects, so
the two cannot drift apart; the function's return type widens to
`int | None`, which any downstream importer should note.

### Testing

The load-bearing test drives the real cipher contexts rather than
pass-through crypto and asserts that the frame after a runt still decodes. It
fails without the length gate, which is the property the gate exists for.
Around it: an unsolicited invalid frame withheld from the state callback and
logged with its hex, an over-length payload refused a level louder, an empty
notification leaving its wait armed with no re-send, a frame racing a
cancelled wait resolving nothing twice, a rejection during a failing write
leaving no unretrieved exception, a valid checksum alone not admitting an
unknown flag byte, a non-UTF-8 characteristic read degrading
to the fallback, a real `SecureSession` handshake frame clearing the gate and
answering its wait, and a parametrised case per truncated advertisement
payload, including the one byte short of the state record.
