### PR TITLE
fix: back off reconnects while updates keep failing

### DIFF
--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -71,6 +71,24 @@ RESYNC_DELAY = 0.01
 
 KEEP_ALIVE_TIME = 25.0  # Lock will disconnect after 30 seconds of inactivity
 
+# Backoff applied to reconnects while updates keep failing. A lock that cannot
+# complete an update disconnects, and the disconnect asks for another attempt
+# straight away, so without this the retry rate is bounded only by how quickly
+# the connection fails. A state-changing advertisement still schedules its own
+# update, so a lock whose advertised state moves is picked up without waiting
+# out the remaining backoff. A lock that recovers without its advertised state
+# changing has no such escape and waits at most MAX_RECONNECT_BACKOFF_TIME,
+# which is the bound this cap is chosen against.
+RECONNECT_BACKOFF_TIME = 2.0
+MAX_RECONNECT_BACKOFF_TIME = 60.0
+
+# Cap on the doubling, not just on the resulting delay. The doubling is
+# evaluated before min() can clamp it, and multiplying a float by a large
+# enough int raises OverflowError, so an unbounded exponent would fault inside
+# a disconnect callback after a long enough run of failures. Any value that
+# reaches MAX_RECONNECT_BACKOFF_TIME is equivalent here.
+MAX_RECONNECT_BACKOFF_DOUBLINGS = 16
+
 # Number of seconds to wait after the first connection
 # to disconnect to free up the bluetooth adapter.
 FIRST_CONNECTION_DISCONNECT_TIME = 2.1
@@ -352,6 +370,7 @@ class PushLock:
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._last_lock_operation_complete_time = NEVER_TIME
         self._last_operation_complete_time = NEVER_TIME
+        self._consecutive_update_failures = 0
         self._always_connected = always_connected
         self._slow_params_set = False
         # Earliest next battery poll attempt (cooldown)
@@ -522,8 +541,24 @@ class PushLock:
         if not self._always_connected:
             return
         _LOGGER.debug("%s: Executing keep alive", self.name)
-        self._schedule_future_update(0)
+        # Debounced, not unconditional: this runs again every KEEP_ALIVE_TIME,
+        # and _schedule_future_update cancels whatever is pending. Re-arming
+        # outright would push any backoff longer than KEEP_ALIVE_TIME further
+        # out every cycle, so it could never fire and the lock would stop
+        # reconnecting instead of slowing down. Debouncing keeps the pending
+        # update whenever it lands sooner than a fresh backoff would.
+        self._schedule_future_update_with_debounce(self._reconnect_backoff_time())
         self._schedule_next_keep_alive(KEEP_ALIVE_TIME)
+
+    def _reconnect_backoff_time(self) -> float:
+        """Return how long to wait before the next reconnect attempt."""
+        if not (failures := self._consecutive_update_failures):
+            return 0.0
+        doublings = min(failures - 1, MAX_RECONNECT_BACKOFF_DOUBLINGS)
+        return min(
+            MAX_RECONNECT_BACKOFF_TIME,
+            RECONNECT_BACKOFF_TIME * 2**doublings,
+        )
 
     def _time_since_last_operation(self) -> float:
         """Return the time since the last operation."""
@@ -845,6 +880,9 @@ class PushLock:
     def _complete_operation(self, now: float) -> None:
         """Mark an operation as complete and reset timers."""
         self._last_operation_complete_time = now
+        # Completing an operation proves the connection works, so the
+        # reconnect backoff must not outlive it.
+        self._consecutive_update_failures = 0
         self._reset_disconnect_timer()
         self._reschedule_next_keep_alive()
 
@@ -957,6 +995,11 @@ class PushLock:
         """Validate lock credentials."""
         _LOGGER.debug("%s: Starting validate", self.name)
         await self._update()
+        # A completed update proves the connection works, the same reasoning
+        # as _complete_operation: do not leave a stale backoff behind it. Only
+        # the reset belongs here; a failed validate is reported to the caller
+        # rather than pacing the always-connected reconnect loop.
+        self._consecutive_update_failures = 0
         _LOGGER.debug("%s: Finished validate", self.name)
 
     async def _poll_battery(self, lock: Lock) -> bool:
@@ -1401,6 +1444,12 @@ class PushLock:
     def _cancel(self) -> None:
         self._running = False
         self._cancel_future_update()
+        # A stop is this library standing down, not the lock failing, the same
+        # reasoning that keeps CancelledError out of the count. _cancel only
+        # flips _running, so this instance can be started again; carrying the
+        # count over would resume it at the capped spacing instead of ramping
+        # from RECONNECT_BACKOFF_TIME.
+        self._consecutive_update_failures = 0
         self.background_task(self._execute_forced_disconnect("stopping"))
 
     def background_task(self, fut: Coroutine[Any, Any, Any]) -> None:
@@ -1506,8 +1555,14 @@ class PushLock:
             _LOGGER.debug("%s: Deferred updated ignored because not running", self.name)
             return
         _LOGGER.debug("%s: Starting deferred update", self.name)
+        # Counted before the attempt rather than in each handler: the lock's
+        # disconnect callback fires while _update() is still running and reads
+        # this count to size the reconnect delay, so counting afterwards would
+        # leave that delay a failure behind. Cleared on success below.
+        self._consecutive_update_failures += 1
         try:
             await self._update()
+            self._consecutive_update_failures = 0
             self._set_update_state(None)
         except AuthError as ex:
             self._set_update_state(ex)
@@ -1516,6 +1571,14 @@ class PushLock:
                 self.name,
             )
         except asyncio.CancelledError:
+            # A cancel is this library giving up on the update, not the lock
+            # failing to service it, so give the count back. Floored at zero:
+            # a completed operation can clear the count while the update is
+            # still in flight, and giving back a count that is no longer there
+            # would go negative and suppress the backoff until it climbed back.
+            self._consecutive_update_failures = max(
+                0, self._consecutive_update_failures - 1
+            )
             self._set_update_state(RuntimeError("Update was canceled"))
             _LOGGER.debug("%s: In-progress update canceled", self.name)
             raise

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -10,6 +10,7 @@ import pytest
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import BleakNotFoundError
 
 from yalexs_ble.const import (
     AuthState,
@@ -35,8 +36,11 @@ from yalexs_ble.push import (
     BATTERY_TIMEOUT_COOLDOWN,
     DEFAULT_ATTEMPTS,
     HAP_FIRST_BYTE,
+    KEEP_ALIVE_TIME,
+    MAX_RECONNECT_BACKOFF_TIME,
     NEVER_TIME,
     NO_BATTERY_SUPPORT_MODELS,
+    RECONNECT_BACKOFF_TIME,
     SLOW_LATENCY,
     SLOW_MAX_INTERVAL,
     SLOW_MIN_INTERVAL,
@@ -46,7 +50,7 @@ from yalexs_ble.push import (
     operation_lock,
     retry_bluetooth_connection_error,
 )
-from yalexs_ble.session import DisconnectedError, ResponseError
+from yalexs_ble.session import AuthError, DisconnectedError, ResponseError
 
 # Shared battery-supporting lock used across tests. model is NOT in
 # NO_BATTERY_SUPPORT_MODELS, so the battery-workaround path is not taken.
@@ -2622,3 +2626,287 @@ async def test_every_read_a_cycle_issues_records_the_round_trip_as_a_success(
 
     assert push_lock.auth == AuthState(successful=True)
     assert _AUTH_FAILURE_HISTORY.should_raise(address) is False
+
+
+def _backoff_lock(address: str) -> PushLock:
+    """Return a running always-connected lock for backoff tests."""
+    push_lock = PushLock(
+        address=address,
+        key="0800200c9a66",
+        key_index=1,
+        always_connected=True,
+    )
+    push_lock._name = "Test Lock"
+    push_lock._running = True
+    return push_lock
+
+
+@pytest.mark.asyncio
+async def test_reconnect_backoff_time_zero_without_failures() -> None:
+    """A lock whose updates are succeeding reconnects immediately."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:40")
+    assert push_lock._reconnect_backoff_time() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_reconnect_backoff_time_grows_and_caps() -> None:
+    """Consecutive failures back off exponentially up to the cap."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:41")
+    delays = []
+    for failures in range(1, 12):
+        push_lock._consecutive_update_failures = failures
+        delays.append(push_lock._reconnect_backoff_time())
+
+    assert delays[0] == RECONNECT_BACKOFF_TIME
+    assert delays[1] == RECONNECT_BACKOFF_TIME * 2
+    assert delays == sorted(delays)
+    assert max(delays) == MAX_RECONNECT_BACKOFF_TIME
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_uses_backoff_while_updates_fail() -> None:
+    """
+    Keep-alive spaces out the reconnect while updates keep failing.
+
+    A failing lock disconnects and the disconnect drives another attempt at
+    once, so without the backoff the retry rate is bounded only by how fast
+    the connection fails.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:42")
+    push_lock._consecutive_update_failures = 3
+
+    with (
+        patch.object(push_lock, "_schedule_future_update") as mock_schedule_update,
+        patch.object(push_lock, "_schedule_next_keep_alive") as mock_next_keep_alive,
+    ):
+        push_lock._keep_alive()
+
+    mock_schedule_update.assert_called_once_with(RECONNECT_BACKOFF_TIME * 4)
+    mock_next_keep_alive.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_deferred_update_failure_counts_toward_backoff() -> None:
+    """Each failed update lengthens the wait before the next reconnect."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:43")
+
+    with patch.object(push_lock, "_update", side_effect=BleakError("boom")):
+        await push_lock._execute_deferred_update()
+        first = push_lock._reconnect_backoff_time()
+        await push_lock._execute_deferred_update()
+
+    assert push_lock._consecutive_update_failures == 2
+    assert push_lock._reconnect_backoff_time() > first > 0
+
+
+@pytest.mark.asyncio
+async def test_deferred_update_success_clears_backoff() -> None:
+    """A completed update drops the lock straight back to immediate retries."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:44")
+    push_lock._consecutive_update_failures = 4
+
+    with patch.object(push_lock, "_update", return_value=None):
+        await push_lock._execute_deferred_update()
+
+    assert push_lock._consecutive_update_failures == 0
+    assert push_lock._reconnect_backoff_time() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_deferred_update_cancel_is_not_a_failure() -> None:
+    """Cancelling an update is this library's doing, so it must not back off."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:45")
+    push_lock._consecutive_update_failures = 2
+
+    with (
+        patch.object(push_lock, "_update", side_effect=asyncio.CancelledError),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await push_lock._execute_deferred_update()
+
+    assert push_lock._consecutive_update_failures == 2
+
+
+@pytest.mark.asyncio
+async def test_complete_operation_clears_backoff() -> None:
+    """A completed operation proves the connection works."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:46")
+    push_lock._consecutive_update_failures = 5
+
+    with (
+        patch.object(push_lock, "_reset_disconnect_timer"),
+        patch.object(push_lock, "_reschedule_next_keep_alive"),
+    ):
+        push_lock._complete_operation(time.monotonic())
+
+    assert push_lock._consecutive_update_failures == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        AuthError("bad key"),
+        TimeoutError("timed out"),
+        BleakNotFoundError("not found"),
+        BleakError("bleak error"),
+        DisconnectedError("disconnected"),
+        ValueError("unexpected"),
+    ],
+)
+async def test_every_update_failure_counts_toward_backoff(exc: Exception) -> None:
+    """
+    Every way an update can fail must feed the backoff.
+
+    Each one leaves the lock disconnected, and the disconnect asks for another
+    attempt straight away, so a failure mode that did not count would keep the
+    reconnect at zero delay.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:47")
+
+    with patch.object(push_lock, "_update", side_effect=exc):
+        await push_lock._execute_deferred_update()
+
+    assert push_lock._consecutive_update_failures == 1
+    assert push_lock._reconnect_backoff_time() == RECONNECT_BACKOFF_TIME
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_does_not_cancel_a_pending_backoff() -> None:
+    """
+    A backoff longer than KEEP_ALIVE_TIME must survive the keep-alive tick.
+
+    ``_keep_alive`` runs again every ``KEEP_ALIVE_TIME`` and
+    ``_schedule_future_update`` cancels whatever is pending, so re-arming
+    outright would push any longer backoff further out on every cycle. The
+    update would never fire and the lock would stop reconnecting altogether
+    rather than settling into a slow poll.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:48")
+    push_lock._consecutive_update_failures = 5
+    assert push_lock._reconnect_backoff_time() > KEEP_ALIVE_TIME
+
+    push_lock._keep_alive()
+    pending = push_lock._cancel_deferred_update
+    assert pending is not None
+    scheduled_for = pending.when()
+
+    push_lock._keep_alive()
+
+    assert push_lock._cancel_deferred_update is pending
+    assert push_lock._cancel_deferred_update.when() == scheduled_for
+
+    push_lock._cancel_future_update()
+    push_lock._cancel_keepalive_timer()
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_still_updates_immediately_when_healthy() -> None:
+    """With no failures the keep-alive must still drive an immediate update."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:49")
+
+    push_lock._keep_alive()
+    pending = push_lock._cancel_deferred_update
+    assert pending is not None
+    assert pending.when() - push_lock.loop.time() < 1.0
+
+    push_lock._cancel_future_update()
+    push_lock._cancel_keepalive_timer()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_backoff_time_survives_a_long_failure_run() -> None:
+    """
+    The doubling must be clamped, not only its result.
+
+    ``2 ** (failures - 1)`` is evaluated before ``min()`` can cap it, and
+    multiplying a float by a large enough int raises ``OverflowError`` inside
+    a disconnect callback.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:4a")
+
+    for failures in (1024, 1025, 100_000):
+        push_lock._consecutive_update_failures = failures
+        assert push_lock._reconnect_backoff_time() == MAX_RECONNECT_BACKOFF_TIME
+
+
+@pytest.mark.asyncio
+async def test_cancel_never_drives_the_failure_count_negative() -> None:
+    """
+    A cancel must not give back a count that was already cleared.
+
+    ``_complete_operation`` zeroes the count when an operation succeeds, and
+    that can land while an update is still in flight. A cancel arriving after
+    it would otherwise decrement past zero, leaving a nonsense fractional
+    backoff and no real backoff until the count climbed back.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:4b")
+
+    async def _clear_then_cancel() -> None:
+        # Stands in for _complete_operation landing mid-update.
+        push_lock._consecutive_update_failures = 0
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(push_lock, "_update", side_effect=_clear_then_cancel),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await push_lock._execute_deferred_update()
+
+    assert push_lock._consecutive_update_failures == 0
+    assert push_lock._reconnect_backoff_time() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_validate_clears_the_backoff() -> None:
+    """A completed validate proves the connection works, so it must reset."""
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:4c")
+    push_lock._consecutive_update_failures = 4
+
+    with patch.object(push_lock, "_update", return_value=None):
+        await push_lock.validate()
+
+    assert push_lock._consecutive_update_failures == 0
+    assert push_lock._reconnect_backoff_time() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_validate_failure_leaves_the_backoff_alone() -> None:
+    """
+    A failed validate must not disturb the count either way.
+
+    It cannot clear a backoff it did not earn, and it does not add to one:
+    the error is raised to the caller rather than pacing the reconnect loop.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:4d")
+    push_lock._consecutive_update_failures = 4
+
+    with (
+        patch.object(push_lock, "_update", side_effect=BleakError("boom")),
+        pytest.raises(BleakError),
+    ):
+        await push_lock.validate()
+
+    assert push_lock._consecutive_update_failures == 4
+
+
+@pytest.mark.asyncio
+async def test_stopping_clears_the_backoff() -> None:
+    """
+    Stopping must not leave a backoff for a later start to inherit.
+
+    ``_cancel`` only flips ``_running``, so the same instance can be started
+    again. ``start`` schedules one immediate update, but if that also fails a
+    carried-over count would resume the keep-alive at the capped spacing
+    rather than ramping from ``RECONNECT_BACKOFF_TIME``.
+    """
+    push_lock = _backoff_lock("aa:bb:cc:dd:ee:4e")
+    push_lock._consecutive_update_failures = 6
+    assert push_lock._reconnect_backoff_time() == MAX_RECONNECT_BACKOFF_TIME
+
+    with patch.object(push_lock, "_execute_forced_disconnect", AsyncMock()):
+        push_lock._cancel()
+        await asyncio.sleep(0)
+
+    assert push_lock._consecutive_update_failures == 0
+    assert push_lock._reconnect_backoff_time() == 0.0


### PR DESCRIPTION
In always_connected mode a failed update leaves the lock disconnected, and the disconnect callback drives another attempt immediately. When the failure is reproducible the two feed each other, so the retry rate is bounded only by how fast the connection fails rather than by any interval this library chooses.

This is not limited to locks that are unreachable. A connection that establishes and then dies partway through the session counts as a completed connection everywhere upstream, so nothing throttles it: one proxy was observed completing 1559 connections in eight hours against 13 and 20 for healthy ones, saturating a radio shared with other locks.

Count consecutive failed updates and delay the reconnect by an exponential backoff, capped so a lock that stays down settles into a slow poll instead of a spin. Any completed update or operation clears the count, since either proves the connection works. A cancelled update is not counted: that is this library giving up, not the lock failing.

Recovery is bounded. A *state-changing* advertisement schedules its own update, and `_schedule_future_update_with_debounce` pulls a pending update earlier when the new request is sooner, so a lock whose advertised state moves is picked up without waiting out the remaining backoff. A lock that recovers without its advertised state changing — the common case when the proxy or radio recovers rather than the latch moving — has no such escape and waits at most `MAX_RECONNECT_BACKOFF_TIME` (60s). That bound is what the cap is chosen against.

Investigative evidence:
A The loop itself — Laundry door. An 8-line cycle repeating every ~1.3 s:
```
10:43:13.160 [yalexs_ble.lock] Laundry door: Disconnected from lock callback
10:43:13.160 [yalexs_ble.push] Laundry door: Disconnected from lock callback
10:43:13.160 [yalexs_ble.push] Laundry door: Scheduling reconnect from disconnected callback
10:43:13.160 [yalexs_ble.push] Laundry door: Executing keep alive
10:43:13.160 [yalexs_ble.push] Laundry door: Scheduling update to happen in 0 seconds
10:43:13.160 [yalexs_ble.push] Laundry door: Scheduling next keep alive in 25.0 seconds
10:43:13.160 [yalexs_ble.push] Laundry door: Rescheduling update since one already in progress
10:43:13.160 [yalexs_ble.push] Laundry door: Scheduling update to happen in 4.1 seconds```
```
Recurring at 10:43:13.160 → 14.834 → 16.085 → 17.330 (+1.67 s, +1.25 s, +1.25 s).

The line that makes the case is the pairing of Scheduling update to happen in 0 seconds with Scheduling next keep alive in 25.0 seconds in the same millisecond. Every cycle asks for 25 s of pacing, and every cycle is pre-empted ~1.3 s later by the next disconnect. KEEP_ALIVE_TIME never gets to be the pacing mechanism.

B. Observed rate vs configured rate
Eleven keep-alives in 11.3 seconds against a 25.0 s interval:
```
10:42:28.655  
10:42:29.901  
10:42:30.744  
10:42:31.985  
10:42:32.825  
10:42:34.081
10:42:35.337  
10:42:36.647  
10:42:38.259  
10:42:39.096  
10:42:39.936
```

C. Exhausting the retries provides no backpressure
Kitchen door, two milliseconds apart:
```
10:42:25.064 Kitchen door: Scheduling update to happen in 0 seconds
10:42:25.066 Kitchen door: <class 'bleak.exc.BleakError'> error calling
             <function PushLock._update ...>, reach max attempts (3/3)
 ```
The zero-delay reconnect is queued before the retry loop reports it gave up — the disconnect callback fires first. So DEFAULT_ATTEMPTS exhaustion contributes nothing to spacing.

D. Even the mild case doubles the rate
Kitchen door keep-alive intervals alternate between the scheduled timer and a disconnect-driven extra:
 ```
10:38:06.306 → 10:38:31.307   +25.001s   (scheduled)
10:38:31.307 → 10:38:47.062   +15.755s   (disconnect-driven)
10:39:12.063 → 10:39:25.869   +13.806s   (disconnect-driven)
10:42:18.318 → 10:42:25.064    +6.746s   (disconnect-driven)
```
