### PR TITLE
fix: retry the lock info probe once before degrading to fallback data

### DIFF
--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -49,6 +49,7 @@ from .session import AuthError, DisconnectedError, Session, YaleXSBLEError
 _LOGGER = logging.getLogger(__name__)
 
 LOCK_INFO_TIMEOUT = 3
+LOCK_INFO_ATTEMPTS = 2
 
 AA_BATTERY_VOLTAGE_TO_PERCENTAGE = (
     (1.55, 100),
@@ -407,38 +408,54 @@ class Lock:
             FIRMWARE_REVISION_CHARACTERISTIC,
         )
         results: dict[str, str] = {}
-        try:
-            async with util.asyncio_timeout(LOCK_INFO_TIMEOUT):
-                for char_uuid in char_uuids:
-                    char = self.client.services.get_characteristic(char_uuid)
-                    if not char:
-                        _LOGGER.warning(
-                            "%s: Characteristic %s not found", self.name, char_uuid
-                        )
-                        continue
-                    try:
-                        results[char_uuid] = (
-                            (await self.client.read_gatt_char(char))
-                            .decode()
-                            .split("\0")[0]
-                        )
-                    # The read is radio input too: the BLE controller bug
-                    # noted above corrupts packets, so the bytes may not be
-                    # UTF-8. A bad read degrades to the fallback for that
-                    # characteristic, like a failed one.
-                    except (BleakError, UnicodeDecodeError) as err:
-                        _LOGGER.warning(
-                            "%s: Failed to read characteristic %s: %s",
-                            self.name,
-                            char_uuid,
-                            err,
-                        )
-        except TimeoutError:
-            _LOGGER.warning(
-                "%s: Timeout reading lock info, using %d partial results",
-                self.name,
-                len(results),
-            )
+        # A transient timeout here must not stand: an empty model reads as no
+        # door sense support, and the consumer caches the result. Retry once
+        # only; the probe runs inside the first update, which setup waits on,
+        # so the worst case has to stay bounded.
+        for attempt in range(LOCK_INFO_ATTEMPTS):
+            try:
+                async with util.asyncio_timeout(LOCK_INFO_TIMEOUT):
+                    for char_uuid in char_uuids:
+                        if char_uuid in results:
+                            continue
+                        char = self.client.services.get_characteristic(char_uuid)
+                        if not char:
+                            _LOGGER.warning(
+                                "%s: Characteristic %s not found", self.name, char_uuid
+                            )
+                            continue
+                        try:
+                            results[char_uuid] = (
+                                (await self.client.read_gatt_char(char))
+                                .decode()
+                                .split("\0")[0]
+                            )
+                        # The read is radio input too: the BLE controller bug
+                        # noted above corrupts packets, so the bytes may not be
+                        # UTF-8. A bad read degrades to the fallback for that
+                        # characteristic, like a failed one.
+                        except (BleakError, UnicodeDecodeError) as err:
+                            _LOGGER.warning(
+                                "%s: Failed to read characteristic %s: %s",
+                                self.name,
+                                char_uuid,
+                                err,
+                            )
+            except TimeoutError:
+                if attempt < LOCK_INFO_ATTEMPTS - 1:
+                    _LOGGER.debug(
+                        "%s: Timeout reading lock info with %d partial results, "
+                        "retrying",
+                        self.name,
+                        len(results),
+                    )
+                    continue
+                _LOGGER.warning(
+                    "%s: Timeout reading lock info, using %d partial results",
+                    self.name,
+                    len(results),
+                )
+            break
         # Use the BLE address as fallback serial to keep devices unique
         # in Home Assistant when the characteristic read fails.
         serial_fallback = self.ble_device_callback().address

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -756,6 +756,105 @@ async def test_lock_info_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_lock_info_timeout_retries_once_then_succeeds() -> None:
+    """A transient timeout on the first pass is retried and recovers.
+
+    An empty model reads as no door sense support and the consumer caches
+    the result, so a single slow read must not stand.
+    """
+    lock, mock_client = _make_lock_with_mock_client()
+    original_read = mock_client.read_gatt_char
+    calls = 0
+
+    async def hang_first_call(char: MagicMock) -> bytes:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await asyncio.sleep(999)
+        return await original_read(char)
+
+    mock_client.read_gatt_char = hang_first_call
+
+    with patch("yalexs_ble.lock.LOCK_INFO_TIMEOUT", 0.05):
+        info = await lock.lock_info()
+
+    assert info == LockInfo(
+        manufacturer="Yale/August",
+        model="ASL-03",
+        serial="12345",
+        firmware="2.0.0",
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_info_retry_keeps_partial_results() -> None:
+    """The retry pass only reads the characteristics still missing."""
+    lock, mock_client = _make_lock_with_mock_client()
+    original_read = mock_client.read_gatt_char
+    mock_to_uuid = mock_client._mock_to_uuid
+    call_counts: dict[str, int] = {}
+
+    async def hang_first_serial_read(char: MagicMock) -> bytes:
+        uuid = mock_to_uuid[id(char)]
+        call_counts[uuid] = call_counts.get(uuid, 0) + 1
+        if uuid == SERIAL_NUMBER_CHARACTERISTIC and call_counts[uuid] == 1:
+            await asyncio.sleep(999)
+        return await original_read(char)
+
+    mock_client.read_gatt_char = hang_first_serial_read
+
+    with patch("yalexs_ble.lock.LOCK_INFO_TIMEOUT", 0.05):
+        info = await lock.lock_info()
+
+    assert info == LockInfo(
+        manufacturer="Yale/August",
+        model="ASL-03",
+        serial="12345",
+        firmware="2.0.0",
+    )
+    # The model landed on the first pass and is not read again.
+    assert call_counts[MODEL_NUMBER_CHARACTERISTIC] == 1
+    assert call_counts[SERIAL_NUMBER_CHARACTERISTIC] == 2
+
+
+@pytest.mark.asyncio
+async def test_lock_info_timeout_on_both_attempts_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both passes timing out degrades to the fallback with one warning."""
+    lock, mock_client = _make_lock_with_mock_client()
+    mock_to_uuid = mock_client._mock_to_uuid
+    read_uuids: list[str] = []
+
+    async def hang_forever(char: MagicMock) -> bytes:
+        read_uuids.append(mock_to_uuid[id(char)])
+        await asyncio.sleep(999)
+        return b""  # unreachable
+
+    mock_client.read_gatt_char = hang_forever
+
+    with patch("yalexs_ble.lock.LOCK_INFO_TIMEOUT", 0.05):
+        info = await lock.lock_info()
+
+    assert info == LockInfo(
+        manufacturer="Yale/August",
+        model="",
+        serial="aa:bb:cc:dd:ee:ff",
+        firmware="Unknown",
+    )
+    # One read per pass proves the retry ran; the warning fires only once,
+    # on the final pass.
+    assert read_uuids == [MODEL_NUMBER_CHARACTERISTIC, MODEL_NUMBER_CHARACTERISTIC]
+    warnings = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING"
+        and "Timeout reading lock info" in record.message
+    ]
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
 async def test_lock_info_missing_characteristic() -> None:
     """Test lock_info skips missing characteristics instead of aborting."""
     lock, mock_client = _make_lock_with_mock_client()


### PR DESCRIPTION
### The problem

`lock_info` reads the model, serial, and firmware characteristics under one 3 second budget with no retry. When the reads run slow, the timeout keeps whatever partial results landed, which can be none, and the model falls back to an empty string. An empty model reads as no door sense support, `_update` caches the result for the life of the `PushLock`, and Home Assistant removes the door sensor entity at setup with "no longer being provided by the yalexs_ble integration". A single transient timeout takes the sensor away until the integration is reloaded.

Seen on a Yale Assure Lock 2:

```
Garage Side Door (98:1B:B5:71:06:5F): Timeout reading lock info, using 0 partial results
```

Reloading the integration brought the sensor back, confirming the timeout was transient.

### The change

`lock_info` retries the timed read pass once, reading only the characteristics still missing so results from the first pass are kept. The retry is bounded at one attempt because the probe runs inside the first update, which setup waits on; more retries would keep the lock from setting up at all. The final timeout keeps the existing warning and fallback, and the outer fallback in `_probe_lock_info` stays as the last resort.
