### PR TITLE
feat: add a staged wait for mechanical operations

### DIFF
--- a/src/yalexs_ble/__init__.py
+++ b/src/yalexs_ble/__init__.py
@@ -11,7 +11,12 @@ from .const import (
 )
 from .lock import Lock
 from .push import PushLock
-from .session import AuthError, DisconnectedError, YaleXSBLEError
+from .session import (
+    AuthError,
+    DisconnectedError,
+    OperationIncompleteError,
+    YaleXSBLEError,
+)
 from .util import (
     ValidatedLockConfig,
     local_name_is_unique,
@@ -33,6 +38,7 @@ __all__ = [
     "LockInfo",
     "LockState",
     "LockStatus",
+    "OperationIncompleteError",
     "PushLock",
     "ValidatedLockConfig",
     "YaleXSBLEDiscovery",

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -169,6 +169,38 @@ def _poll_response_matcher(
     return matches
 
 
+def _ack_matcher(opcode: int, operation_byte: int) -> Callable[[bytes], bool]:
+    """Match the acknowledgment of the written command.
+
+    The acknowledgment carries the operation byte the command was sent
+    with, which is what tells a securemode acknowledgment from a plain
+    lock's on the shared Lock opcode. An op-response carries 0x00 there
+    whatever the operation, which is why _operation_response_matcher
+    matches the opcode alone.
+    """
+
+    def _matches(data: bytes) -> bool:
+        return (
+            len(data) > 0x04
+            and data[0] == 0xAA
+            and data[1] == opcode
+            and data[4] == operation_byte
+        )
+
+    return _matches
+
+
+def _operation_response_matcher(opcode: int) -> Callable[[bytes], bool]:
+    """Match the op-response (0xBB + the sent opcode), emitted when the
+    motor stops.
+    """
+
+    def _matches(data: bytes) -> bool:
+        return len(data) > 0x0F and data[0] == 0xBB and data[1] == opcode
+
+    return _matches
+
+
 class Lock:
     def __init__(
         self,

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -181,10 +181,12 @@ def _ack_matcher(opcode: int, operation_byte: int) -> Callable[[bytes], bool]:
 
     def _matches(data: bytes) -> bool:
         return (
+            # The floor covers the highest byte the match reads, the
+            # operation byte at 0x04.
             len(data) > 0x04
-            and data[0] == 0xAA
-            and data[1] == opcode
-            and data[4] == operation_byte
+            and data[0x00] == 0xAA
+            and data[0x01] == opcode
+            and data[0x04] == operation_byte
         )
 
     return _matches
@@ -196,7 +198,10 @@ def _operation_response_matcher(opcode: int) -> Callable[[bytes], bool]:
     """
 
     def _matches(data: bytes) -> bool:
-        return len(data) > 0x0F and data[0] == 0xBB and data[1] == opcode
+        # The match reads only the identity bytes, but the wait it completes
+        # reads the result at byte 0x0F, so the floor admits only a frame
+        # that carries it.
+        return len(data) > 0x0F and data[0x00] == 0xBB and data[0x01] == opcode
 
     return _matches
 

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from async_interrupt import interrupt
 from bleak import BleakClient
@@ -22,6 +23,22 @@ from .const import READ_CHARACTERISTIC, RESPONSE_FRAME_LEN, WRITE_CHARACTERISTIC
 _LOGGER = logging.getLogger(__name__)
 
 COOLDOWN_TIME = 0.25
+
+# How long execute() waits for the frame answering a command.
+RESPONSE_TIMEOUT = 10.0
+
+# How long stage 1 of a mechanical operation may take: the GATT write and
+# the acknowledgment that follows it. Sized off the link, not the
+# operation: above the ~6 s link supervision timeout, which counts from
+# the last reception, so a link already dead at the write presents as a
+# disconnect, not an expired stage.
+ACK_TIMEOUT = 8.0
+
+# Budget for a whole operation, command write to op-response. The motor
+# runs from the command write, and the acknowledgment is transport
+# acceptance, so a slow acknowledgment does not cut into motion time. An
+# operation with a longer motion passes its own budget.
+OPERATION_RESPONSE_TIMEOUT = 12.0
 
 
 class YaleXSBLEError(Exception):
@@ -46,6 +63,35 @@ class NoAdvertisementError(YaleXSBLEError):
 
 class BluetoothError(YaleXSBLEError):
     """Bluetooth error."""
+
+
+class OperationIncompleteError(YaleXSBLEError):
+    """The operation's result never arrived.
+
+    The command reached the lock, so the motor may have run, but the
+    op-response was lost. Deliberately not a retryable type: it ends the
+    retry attempts with the result unknown.
+    """
+
+
+@dataclass
+class OperationProgress:
+    """How far a mechanical operation got; error handling keys on the stage
+    reached.
+
+    write_attempted is set before the write call, because an errored write
+    can still have delivered the command. acknowledged and result are
+    recorded where the frames arrive, because a disconnect can cancel the
+    operation's wait before it resumes.
+
+    The caller owns the instance and execute_operation never resets it, so
+    recorded values outlive the call and a logically new operation needs a
+    fresh instance.
+    """
+
+    write_attempted: bool = False
+    acknowledged: bool = False
+    result: bytes | None = None
 
 
 class Session:
@@ -74,7 +120,17 @@ class Session:
         )
         self._notifications_started = False
         self._notify_future: asyncio.Future[bytes] | None = None
+        # When set, only a matching frame resolves the pending future; other
+        # valid frames still reach the state callback and the wait continues.
         self._notify_matcher: Callable[[bytes], bool] | None = None
+        # The acknowledgment wait of a staged operation. Armed together
+        # with the response future, before the write, so no frame falls
+        # between the two wait stages.
+        self._ack_future: asyncio.Future[bytes] | None = None
+        self._ack_matcher: Callable[[bytes], bool] | None = None
+        # Set for the whole staged wait, so _notify can tell a staged wait
+        # from a plain one after the acknowledgment stage has passed.
+        self._operation_progress: OperationProgress | None = None
         self._state_callback = state_callback
         self._disconnected_futures = disconnected_futures
         self._first_request = True
@@ -168,10 +224,7 @@ class Session:
     ) -> None:
         """Dispose of a frame that failed admission.
 
-        The frame is withheld from the state callback. A solicited wait still
-        receives the error, so _locked_write re-sends its command until its
-        attempts run out and it raises; an unsolicited frame has no waiter and
-        is dropped.
+        The frame is withheld from the state callback.
         """
         # The drop line carries the frame hex: these frames should not occur at
         # all, so a drop and its evidence are visible without turning debug on,
@@ -179,6 +232,14 @@ class Session:
         _LOGGER.log(
             level, "%s: dropping invalid frame %s: %s", self.name, frame.hex(), ex
         )
+        if self._operation_progress is not None:
+            # Failing a staged wait would re-send a mechanical command whose
+            # result is unknown, so the wait continues; the stage timeout is
+            # the backstop.
+            _LOGGER.debug(
+                "%s: Invalid frame during an operation wait, still waiting", self.name
+            )
+            return
         if (future := self._disarm_wait()) is not None and not future.done():
             future.set_exception(ex)
 
@@ -245,6 +306,21 @@ class Session:
         # why the call is guarded.
         if self._state_callback:
             self._state_callback(decrypted_data)
+        if (
+            (progress := self._operation_progress) is not None
+            and self._ack_future is not None
+            and self._ack_matcher is not None
+            and self._ack_matcher(decrypted_data)
+        ):
+            self._ack_future.set_result(decrypted_data)
+            self._ack_future = None
+            self._ack_matcher = None
+            # Recorded on arrival, not when the wait resumes: a disconnect
+            # can cancel the wait in the same event-loop turn, and an
+            # acknowledgment recorded nowhere reads as a delivery failure,
+            # whose retry re-sends a command the lock has taken.
+            progress.acknowledged = True
+            return
         if self._notify_future is None:
             return
         if self._notify_matcher is not None and not self._notify_matcher(
@@ -259,21 +335,18 @@ class Session:
                 self.name,
             )
             return
+        if progress is not None:
+            # Recorded on arrival for the same reason as the acknowledgment
+            # above.
+            progress.result = decrypted_data
         if (future := self._disarm_wait()) is not None and not future.done():
             future.set_result(decrypted_data)
 
-    async def _locked_write(
-        self,
-        command: bytearray,
-        command_name: str,
-        response_matcher: Callable[[bytes], bool] | None = None,
-    ) -> bytes:
+    def _encrypt_command(self, command: bytearray, command_name: str) -> None:
         # NOTE: The last two bytes are not encrypted
         # General idea seems to be that if the last byte
         # of the command indicates an offline key offset (is non-zero),
         # the command is "secure" and encrypted with the offline key
-        if not self.client.is_connected:
-            raise BleakError("disconnected")
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         plainText = command[0x00:0x10]
         cipherText = self.cipher_encrypt.update(plainText)
@@ -281,6 +354,16 @@ class Session:
         _LOGGER.debug(
             "%s: Encrypted command %s: %s", self.name, command_name, command.hex()
         )
+
+    async def _locked_write(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
+        if not self.client.is_connected:
+            raise BleakError("disconnected")
+        self._encrypt_command(command, command_name)
 
         future: asyncio.Future[bytes] | None = None
         try:
@@ -297,7 +380,7 @@ class Session:
                     command.hex(),
                 )
                 _LOGGER.debug("%s: Waiting for response", self.name)
-                async with util.asyncio_timeout(10):
+                async with util.asyncio_timeout(RESPONSE_TIMEOUT):
                     try:
                         await self.client.write_gatt_char(
                             self.write_characteristic, command, True
@@ -331,6 +414,120 @@ class Session:
                 ):
                     future.exception()
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
+        return result
+
+    async def _locked_write_operation(
+        self,
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        """Write a mechanical command and run the staged wait.
+
+        Starting (or restarting) an operation initialises its timers: both
+        stage deadlines run from the attempt start. Stage 1 (ACK_TIMEOUT)
+        covers the GATT write and the typed acknowledgment; stage 2 (the
+        operation's response_timeout, also from attempt start) covers the
+        op-response, the physical end of movement. Only an op-response, or an
+        error, ends the wait.
+        """
+        if not self.client.is_connected:
+            raise BleakError("disconnected")
+        self._encrypt_command(command, command_name)
+
+        attempt_start = time.monotonic()
+        ack_future: asyncio.Future[bytes] = self.loop.create_future()
+        result_future: asyncio.Future[bytes] = self.loop.create_future()
+        # Armed before the write: re-arming between stages would race an
+        # op-response that follows the acknowledgment within milliseconds.
+        self._ack_future = ack_future
+        self._ack_matcher = ack_matcher
+        self._notify_future = result_future
+        self._notify_matcher = response_matcher
+        self._operation_progress = progress
+        try:
+            _LOGGER.debug(
+                "%s: Writing command to %s: %s",
+                self.name,
+                self.write_characteristic,
+                command.hex(),
+            )
+            # Set before the call: an errored write can still have delivered
+            # the command (the request leaves the radio, only the ATT
+            # response is lost).
+            progress.write_attempted = True
+            async with util.asyncio_timeout(ACK_TIMEOUT):
+                await self.client.write_gatt_char(
+                    self.write_characteristic, command, True
+                )
+            if write_success_callback is not None:
+                # Contained: an exception escaping here would be retried
+                # upstream and re-send a mechanical command. A raising hook
+                # is a bug in the caller.
+                try:
+                    write_success_callback()
+                except Exception:
+                    _LOGGER.exception(
+                        "%s: write success callback for %s raised, "
+                        "continuing the staged wait",
+                        self.name,
+                        command_name,
+                    )
+            _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
+            ack_remaining = ACK_TIMEOUT - (time.monotonic() - attempt_start)
+            done, _ = await asyncio.wait(
+                (ack_future, result_future),
+                timeout=max(ack_remaining, 0),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if result_future in done:
+                # The op-response supersedes the acknowledgment stage: it
+                # either beat the acknowledgment entirely, or both resolved in
+                # the same event-loop turn. Either way the op-response is the
+                # answer, and whether an acknowledgment also arrived was
+                # already recorded where it was received.
+                return result_future.result()
+            if ack_future not in done:
+                raise TimeoutError(
+                    f"{self.name}: No acknowledgment to {command_name} within "
+                    f"{ACK_TIMEOUT}s of the command being issued"
+                )
+            _LOGGER.debug("%s: Waiting for the op-response", self.name)
+            result_remaining = response_timeout - (time.monotonic() - attempt_start)
+            try:
+                async with util.asyncio_timeout(max(result_remaining, 0)):
+                    result = await result_future
+            except TimeoutError as err:
+                if (recorded := progress.result) is not None:
+                    # The op-response arrived in the same event-loop turn as
+                    # the timeout; report the recorded result, not the
+                    # timeout.
+                    _LOGGER.debug(
+                        "%s: op-response to %s arrived in the same turn as "
+                        "the stage-2 timeout; returning the recorded result",
+                        self.name,
+                        command_name,
+                    )
+                    return recorded
+                raise OperationIncompleteError(
+                    f"{self.name}: {command_name} was acknowledged but no "
+                    f"op-response arrived within {response_timeout}s of the "
+                    "command being issued"
+                ) from err
+        finally:
+            # Unconditional: the session lock serializes operations, so the
+            # record armed above is still this operation's own.
+            self._operation_progress = None
+            if self._ack_future is ack_future:
+                self._ack_future = None
+                self._ack_matcher = None
+            if self._notify_future is result_future:
+                self._notify_future = None
+                self._notify_matcher = None
         return result
 
     async def start_notify(self) -> None:
@@ -371,6 +568,20 @@ class Session:
         except BleakError as err:
             _LOGGER.debug("%s: Bleak error stopping notify: %s", self.name, err)
 
+    async def _wait_for_cooldown(self) -> None:
+        while (
+            self._enable_cooldown
+            and (cooldown_remain := time.monotonic() - self._last_callback_time)
+            < COOLDOWN_TIME
+        ):
+            _LOGGER.debug(
+                "%s: Waiting %s for lock to settle", self.name, cooldown_remain
+            )
+            # If we send commands to fast the lock may crash and stop
+            # advertising. This is a workaround to avoid that since
+            # it means a battery pull is required to recover.
+            await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
+
     async def execute(
         self,
         command: bytearray,
@@ -385,18 +596,7 @@ class Session:
         write times out). Without a matcher the first valid frame answers, as
         before.
         """
-        while (
-            self._enable_cooldown
-            and (cooldown_remain := time.monotonic() - self._last_callback_time)
-            < COOLDOWN_TIME
-        ):
-            _LOGGER.debug(
-                "%s: Waiting %s for lock to settle", self.name, cooldown_remain
-            )
-            # If we send commands to fast the lock may crash and stop
-            # advertising. This is a workaround to avoid that since
-            # it means a battery pull is required to recover.
-            await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
+        await self._wait_for_cooldown()
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         self._write_checksum(command)
         disconnected_future = asyncio.get_running_loop().create_future()
@@ -413,6 +613,107 @@ class Session:
                     f"Authentication error: key or slot (key index) is incorrect: {err}"
                 ) from err
             if util.is_disconnected_error(err):
+                raise DisconnectedError(f"{self.name}: {err}") from err
+            raise
+        finally:
+            disconnected_futures.discard(disconnected_future)
+            self._first_request = False
+
+    def _outcome_after_disconnect(
+        self, progress: OperationProgress, command_name: str, err: Exception
+    ) -> bytes | None:
+        """Classify a lost link by how far the operation got.
+
+        Returns the op-response when the frame was recorded before the wait
+        was lost, raises OperationIncompleteError once the command was
+        acknowledged and the result is therefore unknown, and returns None
+        while nothing was acknowledged, which leaves the caller to raise the
+        retryable error the drop came in as.
+        """
+        if (result := progress.result) is not None:
+            # The op-response arrived in the same event-loop turn as the
+            # disconnect; report the recorded result.
+            _LOGGER.debug(
+                "%s: Disconnected in the same turn as the op-response to "
+                "%s; returning the recorded result",
+                self.name,
+                command_name,
+            )
+            return result
+        if progress.acknowledged:
+            raise OperationIncompleteError(
+                f"{self.name}: Disconnected while awaiting the op-response "
+                f"to {command_name}; the result is unknown"
+            ) from err
+        return None
+
+    async def execute_operation(
+        self,
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        """Execute a mechanical operation command with the staged wait.
+
+        Error policy by stage (the caller's retry decorator sees the types).
+        The acknowledgment carries no mechanical delay, so its absence
+        signals a delivery problem and predicts a missing op-response: write
+        and acknowledgment failures keep their retryable types (TimeoutError
+        / DisconnectedError / BleakError) and the retry re-sends the command
+        early rather than waiting out the op-response budget. Once the
+        operation is acknowledged, a timeout or disconnect raises the
+        non-retryable OperationIncompleteError, ending the attempt ladder: the
+        result is unknown and the caller decides.
+
+        response_timeout is the budget for the whole exchange, measured from
+        the moment the command is issued, and must exceed ACK_TIMEOUT: the
+        remainder left once the operation is acknowledged is the op-response
+        wait, so a value at or below ACK_TIMEOUT leaves that wait no time at
+        all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
+        sized here, and an operation with a longer motion passes its own.
+        """
+        await self._wait_for_cooldown()
+        assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
+        self._write_checksum(command)
+        disconnected_future = asyncio.get_running_loop().create_future()
+        disconnected_futures = self._disconnected_futures
+        disconnected_futures.add(disconnected_future)
+        try:
+            async with (
+                interrupt(
+                    disconnected_future,
+                    DisconnectedError,
+                    f"{self.name}: Disconnected",
+                ),
+                self._lock,
+            ):
+                return await self._locked_write_operation(
+                    command,
+                    command_name,
+                    ack_matcher,
+                    response_matcher,
+                    response_timeout,
+                    progress,
+                    write_success_callback,
+                )
+        except DisconnectedError as err:
+            result = self._outcome_after_disconnect(progress, command_name, err)
+            if result is not None:
+                return result
+            raise
+        except BleakError as err:
+            if self._first_request and util.is_key_error(err):
+                raise AuthError(
+                    f"Authentication error: key or slot (key index) is incorrect: {err}"
+                ) from err
+            if util.is_disconnected_error(err):
+                result = self._outcome_after_disconnect(progress, command_name, err)
+                if result is not None:
+                    return result
                 raise DisconnectedError(f"{self.name}: {err}") from err
             raise
         finally:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from time import monotonic
 
 from async_interrupt import interrupt
 from bleak import BleakClient
@@ -244,7 +244,7 @@ class Session:
             future.set_exception(ex)
 
     def _notify(self, char: int, data: bytearray) -> None:
-        self._last_callback_time = time.monotonic()
+        self._last_callback_time = monotonic()
         _LOGGER.debug(
             "%s: Receiving response via notify: %s (waiting=%s)",
             self.name,
@@ -439,7 +439,7 @@ class Session:
             raise BleakError("disconnected")
         self._encrypt_command(command, command_name)
 
-        attempt_start = time.monotonic()
+        attempt_start = monotonic()
         ack_future: asyncio.Future[bytes] = self.loop.create_future()
         result_future: asyncio.Future[bytes] = self.loop.create_future()
         # Armed before the write: re-arming between stages would race an
@@ -478,7 +478,7 @@ class Session:
                         command_name,
                     )
             _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
-            ack_remaining = ACK_TIMEOUT - (time.monotonic() - attempt_start)
+            ack_remaining = ACK_TIMEOUT - (monotonic() - attempt_start)
             done, _ = await asyncio.wait(
                 (ack_future, result_future),
                 timeout=max(ack_remaining, 0),
@@ -502,7 +502,7 @@ class Session:
                     f"{ACK_TIMEOUT}s of the command being issued"
                 )
             _LOGGER.debug("%s: Waiting for the op-response", self.name)
-            result_remaining = response_timeout - (time.monotonic() - attempt_start)
+            result_remaining = response_timeout - (monotonic() - attempt_start)
             try:
                 async with util.asyncio_timeout(max(result_remaining, 0)):
                     result = await result_future
@@ -576,7 +576,7 @@ class Session:
     async def _wait_for_cooldown(self) -> None:
         while (
             self._enable_cooldown
-            and (cooldown_remain := time.monotonic() - self._last_callback_time)
+            and (cooldown_remain := monotonic() - self._last_callback_time)
             < COOLDOWN_TIME
         ):
             _LOGGER.debug(

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -675,10 +675,10 @@ class Session:
         result is unknown and the caller decides.
 
         response_timeout is the budget for the whole exchange, measured from
-        the moment the command is issued, and must exceed ACK_TIMEOUT: the
+        the moment the command is issued. Size it above ACK_TIMEOUT: the
         remainder left once the operation is acknowledged is the op-response
-        wait, so a value at or below ACK_TIMEOUT leaves that wait no time at
-        all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
+        wait, so a budget at or below ACK_TIMEOUT leaves that wait no time
+        at all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
         sized here, and an operation with a longer motion passes its own.
         """
         await self._wait_for_cooldown()

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -495,6 +495,13 @@ class Session:
                 # residual is accepted: requiring the acknowledgment first
                 # would instead drop a genuine op-response whose
                 # acknowledgment was lost.
+                if not progress.acknowledged:
+                    _LOGGER.info(
+                        "%s: %s completed on its op-response; no "
+                        "acknowledgment was received",
+                        self.name,
+                        command_name,
+                    )
                 return result_future.result()
             if ack_future not in done:
                 raise TimeoutError(

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -489,7 +489,12 @@ class Session:
                 # either beat the acknowledgment entirely, or both resolved in
                 # the same event-loop turn. Either way the op-response is the
                 # answer, and whether an acknowledgment also arrived was
-                # already recorded where it was received.
+                # already recorded where it was received. The matcher keys on
+                # the opcode alone, so the frame taken here can also be a
+                # previous same-opcode command's late op-response. That
+                # residual is accepted: requiring the acknowledgment first
+                # would instead drop a genuine op-response whose
+                # acknowledgment was lost.
                 return result_future.result()
             if ack_future not in done:
                 raise TimeoutError(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -29,6 +29,8 @@ from yalexs_ble.const import (
 from yalexs_ble.lock import (
     AA_BATTERY_VOLTAGE_TO_PERCENTAGE,
     Lock,
+    _ack_matcher,
+    _operation_response_matcher,
     _poll_response_matcher,
     _settings_response_matcher,
     convert_voltage_to_percentage,
@@ -975,3 +977,31 @@ async def test_the_auto_lock_read_completes_on_its_acknowledgment() -> None:
     session.client.write_gatt_char = AsyncMock(side_effect=deliver)
 
     await lock.auto_lock_status()
+
+
+def test_ack_matcher_matches_only_the_written_operation() -> None:
+    """The ack matcher keys on 0xAA + the written opcode + operation byte."""
+    matches = _ack_matcher(0x0B, 0x04)
+
+    # Correct ack: 0xAA, opcode 0x0B, operation byte 0x04.
+    assert matches(bytes.fromhex("aa0b00450400000000000000000000000200"))
+    # Same opcode but operation byte 0x00, a plain-lock ack, not securemode.
+    assert not matches(bytes.fromhex("aa0b00490000000000000000000000000200"))
+    # Wrong opcode (0x0A).
+    assert not matches(bytes.fromhex("aa0a004a0000000000000000000000000200"))
+    # An op-response (0xBB), not an acknowledgment.
+    assert not matches(bytes.fromhex("bb0b00450400000000000000000000000200"))
+
+
+def test_operation_response_matcher_matches_only_its_opcode() -> None:
+    """The op-response matcher keys on 0xBB + the sent opcode, full length."""
+    matches = _operation_response_matcher(0x0A)
+
+    # An 18-byte 0xBB 0x0A op-response.
+    assert matches(bytes.fromhex("bb0a00000000000000000000000000000200"))
+    # Wrong opcode (0x0B).
+    assert not matches(bytes.fromhex("bb0b00000000000000000000000000000200"))
+    # An acknowledgment (0xAA), not an op-response.
+    assert not matches(bytes.fromhex("aa0a00000000000000000000000000000200"))
+    # Truncated: byte[15] (the result) is not present.
+    assert not matches(bytes.fromhex("bb0a0000000000000000"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -963,6 +963,42 @@ async def test_execute_operation_op_response_before_ack() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
+    """A previous same-opcode command's late op-response is taken as the answer.
+
+    An op-response is matched on the opcode alone, so a fresh wait cannot
+    tell its own answer from the previous same-opcode command's late one:
+    fed during stage 1, the stale frame completes the wait through the
+    supersede branch. progress.acknowledged staying False is the tell that
+    the result may not be this command's.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    # The same bytes a previous lock-opcode command's op-response carries.
+    stale_op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # Arrives before this command's acknowledgment.
+        session._notify(0, bytearray(stale_op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(stale_op_response)
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
 async def test_execute_operation_ack_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,8 @@
-"""Session-level tests for frame admission and the solicited-response matcher."""
+"""Session-level tests for frame admission, the response matcher and the staged wait."""
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,9 +12,25 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from yalexs_ble import util
 from yalexs_ble.const import Commands, SettingType
-from yalexs_ble.lock import _settings_response_matcher
+from yalexs_ble.lock import (
+    _ack_matcher,
+    _operation_response_matcher,
+    _settings_response_matcher,
+)
+from yalexs_ble.push import RETRYABLE_EXCEPTIONS, SLOW_TIMEOUT
 from yalexs_ble.secure_session import SecureSession
-from yalexs_ble.session import RESPONSE_FRAME_LEN, ResponseError, Session
+from yalexs_ble.session import (
+    ACK_TIMEOUT,
+    COOLDOWN_TIME,
+    OPERATION_RESPONSE_TIMEOUT,
+    RESPONSE_FRAME_LEN,
+    AuthError,
+    DisconnectedError,
+    OperationIncompleteError,
+    OperationProgress,
+    ResponseError,
+    Session,
+)
 
 # Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
 # acknowledgment and, ~40 ms later, the 0xBB frame carrying the stored value
@@ -121,7 +138,9 @@ async def test_corrupt_frame_disarms_the_wait_and_the_command_is_retried() -> No
 
     The corrupt frame resolves the future with a ResponseError, so the matcher
     must be cleared with it -- otherwise the retry re-arms the wait with the
-    previous command's matcher still in place.
+    previous command's matcher still in place. The staged operation wait skips
+    corrupt frames instead; this is the plain path, where re-writing a settings
+    command costs nothing.
     """
     received: list[bytes] = []
     session = _make_session(received)
@@ -540,3 +559,1271 @@ async def test_a_secure_session_handshake_frame_still_answers_its_wait() -> None
     assert len(on_air) == RESPONSE_FRAME_LEN
     result = await session.execute(session.build_command(0x01), "KEY_EXCHANGE")
     assert result == bytes(answer)
+
+
+def _with_checksum(hex_str: str) -> bytearray:
+    """Build an 18-byte frame with a valid simple checksum in byte[3].
+
+    _validate_response requires the 18-byte simple checksum to sum to zero;
+    byte[3] is the checksum field, so set it to whatever makes that hold.
+    """
+    frame = bytearray.fromhex(hex_str)
+    frame[0x03] = 0
+    frame[0x03] = util._simple_checksum(frame)
+    return frame
+
+
+async def _spin_until(predicate: Callable[[], bool]) -> None:
+    """Yield to the event loop until predicate() holds (bounded).
+
+    Lets the operation under test advance to its next awaited stage before the
+    test feeds the next frame, so each _notify lands in the intended stage.
+    """
+    for _ in range(1000):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition was never reached")
+
+
+async def _spin_until_written(client: MagicMock, writes: int = 1) -> None:
+    """Yield until the GATT write has returned.
+
+    The write is where the staged wait begins: both stage futures are armed
+    before it, and the writer reaches its first await straight after it. A
+    frame fed once the write has returned therefore lands in the stage the
+    test intends.
+    """
+    await _spin_until(lambda: client.write_gatt_char.await_count >= writes)
+
+
+def _make_operation_session(
+    state_callback: Callable[[bytes], None] | None = None,
+) -> tuple[Session, MagicMock]:
+    """Build a Session over a mock client for the notify/staged-wait path.
+
+    Only cipher_encrypt is set (execute_operation asserts it); cipher_decrypt
+    is left None so notify frames pass through Session.decrypt unmodified.
+    """
+    client = MagicMock()
+    client.is_connected = True
+    client.write_gatt_char = AsyncMock()
+    session = Session(client, "mylock", asyncio.Lock(), set(), state_callback)
+    session.cipher_encrypt = Cipher(
+        algorithms.AES(bytes(16)),
+        modes.CBC(bytes(16)),
+    ).encryptor()
+    return session, client
+
+
+# securemode = LOCK opcode (0x0B) with operation byte 0x04.
+_ACK_SECUREMODE = "aa0b00000400000000000000000000000200"
+_OP_RESPONSE_OK = "bb0b00000000000000000000000000000200"
+_SETTLED_STATUS = "bb0200000200000000000000000000000200"
+_FOREIGN_ACK = "aa0b00000000000000000000000000000200"
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_happy_path() -> None:
+    """Write, then ack, then op-response: returns the op-response bytes.
+
+    write_success_callback fires once, before the ack is delivered.
+    """
+    order: list[str] = []
+    session, client = _make_operation_session()
+    write_cb = MagicMock(side_effect=lambda: order.append("write"))
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        order.append("ack")
+        session._notify(0, bytearray(ack))
+        # Deliver the op-response in the SAME event-loop turn: both stage
+        # futures resolve before the writer resumes, exercising the
+        # supersede branch, which must still record the acknowledgment.
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+        write_success_callback=write_cb,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert client.write_gatt_char.await_count == 1
+    assert progress.write_attempted is True
+    assert progress.acknowledged is True
+    write_cb.assert_called_once()
+    # The callback fired before the ack was delivered.
+    assert order == ["write", "ack"]
+
+
+@pytest.mark.asyncio
+async def test_a_raising_write_success_callback_does_not_abort_the_staged_wait(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A write_success_callback that raises is contained, and the wait goes on.
+
+    The hook runs after the command is confirmed delivered, so an exception
+    escaping it would abandon a wait whose motor may be running, and the
+    escaped type would be retried upstream and re-send the command. The
+    exception is logged at error level, since a raising hook is a bug in the
+    caller, and the staged wait still completes on its op-response.
+    """
+    session, client = _make_operation_session()
+    write_cb = MagicMock(side_effect=RuntimeError("hook bug"))
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    with caplog.at_level("ERROR", logger="yalexs_ble.session"):
+        result = await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+            write_success_callback=write_cb,
+        )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+    write_cb.assert_called_once()
+    assert "write success callback for force_securemode raised" in caplog.text
+    assert "hook bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_ignores_foreign_frames() -> None:
+    """A settle and a foreign ack mid-wait do not complete the operation."""
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    settled = _with_checksum(_SETTLED_STATUS)
+    foreign_ack = _with_checksum(_FOREIGN_ACK)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # A settled GETSTATUS (0xBB 0x02) and a foreign ack (0xAA 0x0B with
+        # operation byte 0x00, not the securemode 0x04) must not complete it.
+        session._notify(0, bytearray(settled))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(foreign_ack))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+    # The foreign frames were still handed to the state callback.
+    assert bytes(settled) in seen
+    assert bytes(foreign_ack) in seen
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_acknowledgment_is_inert_and_the_operation_completes() -> None:
+    """A second matching acknowledgment resolves nothing and raises nothing.
+
+    The acknowledgment slot is cleared as the first matching frame resolves
+    it, which is what makes the resolution safe without a done() check. Left
+    armed, the duplicate would resolve a future that is already done and raise
+    InvalidStateError inside the notify callback, which the Bluetooth stack
+    calls with nobody to catch it.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    escaped: list[BaseException] = []
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        try:
+            # The same acknowledgment again, now in the op-response stage.
+            session._notify(0, bytearray(ack))
+        except Exception as err:
+            escaped.append(err)
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert escaped == []
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_operation_wait_skips_a_corrupt_frame_and_completes() -> None:
+    """A frame that fails the checksum mid-operation is skipped, not surfaced.
+
+    On the plain path a checksum failure ends the wait so the caller can write
+    the command again. A mechanical command must not be written again on the
+    strength of a bad frame, so the operation wait skips it and keeps waiting
+    for the op-response.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    # The op-response frame with its checksum field broken, so it decodes as
+    # this command's answer but fails validation.
+    corrupt = bytearray(op_response)
+    corrupt[0x03] ^= 0xFF
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(corrupt))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    # The corrupt frame neither answered the command nor ended the wait.
+    assert result == bytes(op_response)
+    assert session.client.write_gatt_char.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_wait_skips_a_corrupt_frame_after_the_acknowledgment() -> None:
+    """A corrupt frame in the op-response stage is skipped too.
+
+    The acknowledgment's own arming is cleared the moment it arrives, so the
+    op-response stage looks exactly like a plain wait; _operation_progress is
+    what still marks it as an operation. Keying the skip on the acknowledgment
+    arming instead would error this wait and re-send a mechanical command the
+    lock has already taken.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    corrupt = bytearray(op_response)
+    corrupt[0x03] ^= 0xFF
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(corrupt))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert session.client.write_gatt_char.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_progress_is_cleared_so_the_plain_path_still_retries() -> None:
+    """The staged wait clears its progress record on the way out.
+
+    _operation_progress is what tells _notify to skip a corrupt frame rather
+    than error the wait. Left set after an operation, it would disable the
+    plain path's corrupt-frame retry for the life of the connection.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    await session.execute_operation(
+        session.build_operation_command(Commands.LOCK, 0x04),
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert session._operation_progress is None
+
+    # A plain command behind the operation: its corrupt frame must still end
+    # the wait and make _locked_write write the command again.
+    good = _with_checksum(_SETTLED_STATUS)
+    bad = bytearray(good)
+    bad[0x03] ^= 0xFF
+    frames = [bad, good]
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(frames.pop(0)))
+
+    client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(
+        session.build_command(Commands.GETSTATUS), "lock_status"
+    )
+
+    assert result == bytes(good)
+    assert client.write_gatt_char.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_op_response_before_ack() -> None:
+    """The op-response alone completes the wait; the ack stage is superseded."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    # No acknowledgment was needed to complete.
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_ack_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No acknowledgment within the ack budget raises a plain TimeoutError."""
+    monkeypatch.setattr("yalexs_ble.session.ACK_TIMEOUT", 0.05)
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    # A plain TimeoutError, not the non-retryable OperationIncompleteError:
+    # nothing was acknowledged, so the command may still be retried.
+    assert not isinstance(exc_info.value, OperationIncompleteError)
+    assert client.write_gatt_char.await_count == 1
+    assert progress.acknowledged is False
+
+
+def test_ack_timeout_outlasts_the_link_supervision_timeout() -> None:
+    """Stage 1 must outlast a dead link, so a dead link reads as a disconnect.
+
+    SLOW_TIMEOUT is the slow-mode supervision timeout in BLE units of 10 ms.
+    Below it, a link that has already gone expires this stage instead, and a
+    missing acknowledgment is retryable: the command would be written again
+    to a lock that may have taken it.
+    """
+    assert ACK_TIMEOUT > SLOW_TIMEOUT / 100
+
+
+def test_operation_response_timeout_outlasts_the_acknowledgment_budget() -> None:
+    """Stage 2's budget must exceed stage 1's.
+
+    Both stage deadlines run from the command issue, so everything the
+    acknowledgment stage consumes comes out of the op-response budget; a
+    budget at or below ACK_TIMEOUT could reach stage 2 with nothing left and
+    fail the operation the moment the acknowledgment lands. The relationship
+    is the invariant; the value itself is sized off the observed op-response
+    arrival distribution and moves with it.
+    """
+    assert OPERATION_RESPONSE_TIMEOUT > ACK_TIMEOUT
+
+
+def test_operation_incomplete_error_passes_the_retry_decorator() -> None:
+    """The type's whole purpose is to end the attempt ladder.
+
+    Its docstring says it is deliberately outside the bleak retry set, and
+    the consequence of losing that is a mechanical command re-sent after its
+    result went missing. Reparenting it under ResponseError would do exactly
+    that and leaves every other test in this file green.
+    """
+    assert not issubclass(OperationIncompleteError, RETRYABLE_EXCEPTIONS)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_op_response_timeout() -> None:
+    """Acknowledged but no op-response raises the non-retryable error."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=0.1,
+            progress=progress,
+        )
+    await feeder
+
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_stage_deadlines_run_from_the_command_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both stage timeouts subtract the time already spent in the attempt.
+
+    The acknowledgment wait asks for ACK_TIMEOUT minus the time the
+    write consumed, and the op-response wait asks for response_timeout minus
+    everything spent up to the acknowledgment, so the whole operation is
+    bounded from the moment the command is issued, exactly as
+    OperationIncompleteError's message states.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+
+    async def write_taking_half_a_second(*args: object, **kwargs: object) -> None:
+        clock["now"] += 0.5
+
+    client.write_gatt_char = AsyncMock(side_effect=write_taking_half_a_second)
+
+    ack_wait_timeouts: list[float | None] = []
+    real_wait = asyncio.wait
+
+    async def spying_wait(fs: object, **kwargs: object) -> object:
+        ack_wait_timeouts.append(kwargs.get("timeout"))  # type: ignore[arg-type]
+        return await real_wait(fs, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.wait", spying_wait)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        clock["now"] += 2.5  # the acknowledgment lands 3.0 s into the attempt
+        session._notify(0, bytearray(ack))
+        # The op-response must land in the op-response stage, so wait for that
+        # stage to arm its own bound rather than for progress.acknowledged,
+        # which is set as the frame is received and so is already true here.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=12.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    # The write consumed 0.5 s of the attempt, so the acknowledgment stage
+    # asked for the remainder of ACK_TIMEOUT, not the full budget again.
+    assert ack_wait_timeouts == [pytest.approx(ACK_TIMEOUT - 0.5)]
+    # The first bound is the write stage's own, ACK_TIMEOUT. The
+    # acknowledgment then spent 3.0 s of the 12.0 s response budget, so the
+    # op-response stage asked for the 9.0 s remainder.
+    assert op_wait_timeouts == [
+        pytest.approx(ACK_TIMEOUT),
+        pytest.approx(9.0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_response_matcher_skips_nonmatching_and_bad_frames() -> None:
+    """The plain execute path waits past a non-matching and a garbled frame."""
+    session, _ = _make_operation_session()
+    command = session.build_command(Commands.GETSTATUS)
+
+    def matcher(data: bytes) -> bool:
+        return len(data) > 1 and data[0] == 0xBB and data[1] == 0x02
+
+    nonmatching = _with_checksum(_OP_RESPONSE_OK)  # valid 0xBB 0x0B, wrong op
+    good = _with_checksum(_SETTLED_STATUS)  # valid 0xBB 0x02, matches
+    bad = _with_checksum(_SETTLED_STATUS)
+    bad[0x03] = (bad[0x03] + 1) & 0xFF  # corrupt the checksum
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._notify_future is not None)
+        session._notify(0, bytearray(nonmatching))
+        await asyncio.sleep(0)
+        # A garbled frame during a plain wait DOES end it, matcher or no
+        # matcher: the wait is errored and _locked_write writes the command
+        # again. Only a staged operation wait skips corrupt frames.
+        session._notify(0, bytearray(bad))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(good))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute(command, "lock_status", matcher)
+    await feeder
+
+    assert result == bytes(good)
+    assert session.client.write_gatt_char.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cooldown_paces_a_command_behind_the_last_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the cooldown enabled, a command waits out the rest of COOLDOWN_TIME.
+
+    Both write paths share this wait. A command sent too soon after a frame
+    can stop the lock advertising, which needs a battery pull to recover, so
+    the session paces itself off the last frame it saw.
+    """
+    session, _ = _make_operation_session()
+    session.enable_cooldown()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    session._last_callback_time = clock["now"] - 0.2
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.sleep", fake_sleep)
+    await session._wait_for_cooldown()
+
+    assert slept == [pytest.approx(COOLDOWN_TIME - 0.2)]
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_pays_the_cooldown_before_its_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mechanical command waits out the cooldown before it is written.
+
+    A command written too soon after the lock's last frame can stop the lock
+    advertising, so the operation path pays the same wait as the settings
+    path rather than writing straight away.
+    """
+    session, client = _make_operation_session()
+    session.enable_cooldown()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    session._last_callback_time = clock["now"] - 0.2
+    slept: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        if delay:
+            slept.append(delay)
+            clock["now"] += delay
+        # The cooldown's own wait is the one under test; every other sleep in
+        # this test is a yield, so hand the loop a real one.
+        await real_sleep(0)
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.sleep", fake_sleep)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        session.build_operation_command(Commands.LOCK, 0x04),
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=OperationProgress(),
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert slept == [pytest.approx(COOLDOWN_TIME - 0.2)]
+
+
+# =========================================================================== #
+# Disconnect / auth contract of the operation wait
+#
+# The pre/post-acknowledgment retry hinge: a failure BEFORE the ack keeps its
+# retryable type (the command never moved the motor); once acknowledged the
+# result is unknown, so a disconnect or timeout becomes the non-retryable
+# OperationIncompleteError and the command is never silently re-sent. These
+# tests pin that contract so a future change that makes an acknowledged
+# operation retryable again fails the suite instead of shipping.
+# =========================================================================== #
+def _fire_disconnect(session: Session) -> None:
+    """Resolve the operation's disconnected future, as a link drop would.
+
+    execute_operation registers a future in _disconnected_futures and wraps the
+    wait in async_interrupt.interrupt(...); resolving that future raises
+    DisconnectedError inside the wait.
+    """
+    for fut in list(session._disconnected_futures):
+        if not fut.done():
+            fut.set_result(None)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_disconnect_after_ack_is_operation_incomplete() -> None:
+    """Disconnect AFTER the ack -> non-retryable OperationIncompleteError."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        _fire_disconnect(session)  # link drops while awaiting the op-response
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+
+@pytest.mark.asyncio
+async def test_ack_and_disconnect_in_one_turn_is_operation_incomplete() -> None:
+    """Ack and disconnect in ONE event-loop turn -> non-retryable.
+
+    The interrupt cancels the staged wait before it resumes, so nothing in the
+    wait body observes the acknowledgment. It still has to be recorded, or the
+    drop is classified as a pre-acknowledgment disconnect and the command is
+    re-sent to a lock that already took it.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # Both resolutions land in the same turn, with no await between them.
+        session._notify(0, bytearray(ack))
+        _fire_disconnect(session)
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_op_response_and_disconnect_in_one_turn_returns_the_result() -> None:
+    """Op-response and disconnect in ONE event-loop turn -> the result stands.
+
+    The twin of the acknowledgment race, with the opposite consequence: the
+    interrupt cancels the staged wait before it resumes, so the wait body never
+    sees the op-response it was given. Recorded where the frame arrives, the
+    result is in hand and a completed operation is reported as completed
+    instead of as one whose result never arrived.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # Both land in the same turn, with no await between them.
+        session._notify(0, bytearray(op_response))
+        _fire_disconnect(session)
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Op-response and stage-2 timeout in ONE event-loop turn -> the result stands.
+
+    The third twin, with the timer in the disconnect's role: the notify
+    delivering the op-response and the stage-2 timeout handle can become due
+    in the same event-loop iteration, and the timeout then cancels the wait
+    before it can resume with the result the future already holds. Recorded
+    where the frame arrives, the result is in hand and is returned instead of
+    raising OperationIncompleteError.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        # Wait for the op-response stage to arm its own timer, so the blocking
+        # sleep below expires that timer and not the acknowledgment stage's.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.05, session._notify, 0, bytearray(op_response))
+        # Block the loop past both deadlines: when it wakes, the notify handle
+        # (the earlier deadline) and the stage-2 timeout handle run in the
+        # same iteration, notify first, reproducing the race. The blocking
+        # sleep is the point, so the async lint rule is suppressed.
+        time.sleep(0.4)  # noqa: ASYNC251
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=0.2,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The op-response due after the stage-2 deadline still stands.
+
+    The twin of the ordering above: the two handles become due in one
+    event-loop iteration with the deadline the earlier of them, so the wait is
+    cancelled first and the frame lands on a wait that has not yet resumed.
+    Recorded where the frame arrives, the result is in hand either way round.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        # Wait for the op-response stage to arm its own timer, so the blocking
+        # sleep below expires that timer and not the acknowledgment stage's.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.25, session._notify, 0, bytearray(op_response))
+        # Block the loop past both deadlines: when it wakes, the stage-2
+        # timeout handle (the earlier deadline) and the notify handle run in
+        # the same iteration, the timeout first, which is the ordering this
+        # test pins. The blocking sleep is the point, so the async lint rule
+        # is suppressed.
+        time.sleep(0.4)  # noqa: ASYNC251
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=0.2,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_disconnect_before_ack_stays_retryable() -> None:
+    """Disconnect BEFORE the ack -> plain DisconnectedError (retryable)."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        _fire_disconnect(session)  # link drops before any acknowledgment
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(DisconnectedError) as exc_info:
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+    # Retryable: not the non-retryable type, and nothing was acknowledged.
+    assert not isinstance(exc_info.value, OperationIncompleteError)
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_key_error_on_write_raises_auth_error() -> None:
+    """A key/slot error on the first request surfaces as AuthError."""
+    session, client = _make_operation_session()
+    client.write_gatt_char = AsyncMock(side_effect=BleakError("Unlikely Error"))
+
+    with pytest.raises(AuthError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=OperationProgress(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_not_connected_raises_disconnected() -> None:
+    """The pre-write connected-guard raises, converted to DisconnectedError.
+
+    The one exit taken before the write call, so it is where write_attempted
+    stays False: a caller that must never re-send a command reads that
+    record, and every later exit has to report the command as possibly
+    delivered.
+    """
+    session, client = _make_operation_session()
+    client.is_connected = False
+    progress = OperationProgress()
+
+    with pytest.raises(DisconnectedError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert progress.write_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_errored_write_still_reports_the_write_as_attempted() -> None:
+    """An error raised by the write call leaves write_attempted True.
+
+    The request PDU can leave the radio with only the ATT response lost, so
+    an error from the write leaves delivery unknown, and write_attempted is
+    what carries that to the caller: set after the call instead, an errored
+    write would report False and read as a command that was never sent.
+    """
+    session, client = _make_operation_session()
+    client.write_gatt_char.side_effect = BleakError("write failed")
+    progress = OperationProgress()
+
+    with pytest.raises(BleakError, match="write failed"):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert progress.write_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_bleak_disconnect_after_ack_is_operation_incomplete() -> None:
+    """Defensive branch: a BleakError disconnect surfacing AFTER the ack is also
+    treated as an unknown result (OperationIncompleteError), not a retry."""
+    session, _ = _make_operation_session()
+    progress = OperationProgress()
+
+    def _boom(
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        progress.acknowledged = True
+        raise BleakError("device disconnected")
+
+    with (
+        patch.object(session, "_locked_write_operation", AsyncMock(side_effect=_boom)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+
+@pytest.mark.asyncio
+async def test_bleak_disconnect_in_one_turn_with_the_op_response_returns_it() -> None:
+    """The same twin on the BleakError arm: a recorded result still stands."""
+    session, _ = _make_operation_session()
+    progress = OperationProgress()
+    op_response = bytes(_with_checksum(_OP_RESPONSE_OK))
+
+    def _boom(
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        progress.acknowledged = True
+        progress.result = op_response
+        raise BleakError("device disconnected")
+
+    with patch.object(session, "_locked_write_operation", AsyncMock(side_effect=_boom)):
+        result = await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert result == op_response
+
+
+@pytest.mark.asyncio
+async def test_execute_settings_not_connected_raises_disconnected() -> None:
+    """The settings/poll path's pre-write connected-guard also raises."""
+    session, client = _make_operation_session()
+    client.is_connected = False
+
+    with pytest.raises(DisconnectedError):
+        await session.execute(session.build_command(Commands.GETSTATUS), "status")
+
+
+@pytest.mark.asyncio
+async def test_notify_returns_when_only_ack_is_armed_and_frame_does_not_match() -> None:
+    """A frame the acknowledgment matcher refuses resolves nothing.
+
+    The operation record and the acknowledgment wait are both armed, so the
+    matcher is consulted, and with no result wait behind it the frame is
+    dropped once the state callback has seen it.
+    """
+    session, _ = _make_operation_session()
+    # The record is what admits a frame to the acknowledgment branch at all;
+    # without it the matcher below is never reached.
+    session._operation_progress = OperationProgress()
+    session._ack_future = asyncio.get_running_loop().create_future()
+    matcher = _ack_matcher(0x0B, 0x04)
+    offered: list[bytes] = []
+
+    def counting_matcher(data: bytes) -> bool:
+        offered.append(data)
+        return matcher(data)
+
+    session._ack_matcher = counting_matcher
+    session._notify_future = None
+    session._notify_matcher = None
+
+    # A settled GETSTATUS (0xBB) never matches the 0xAA ack matcher.
+    frame = _with_checksum(_SETTLED_STATUS)
+    session._notify(0, bytearray(frame))
+
+    assert offered == [bytes(frame)]
+    assert not session._ack_future.done()
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_generic_bleak_error_is_reraised() -> None:
+    """A BleakError that is neither a key nor a disconnect error re-raises as-is.
+
+    It stays a plain (retryable) BleakError, not converted to AuthError or
+    DisconnectedError, so the write may simply be retried.
+    """
+    session, client = _make_operation_session()
+    client.write_gatt_char = AsyncMock(side_effect=BleakError("GATT write failed"))
+
+    with pytest.raises(BleakError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=OperationProgress(),
+        )
+
+
+# =========================================================================== #
+# 1000 ms field replays: the typed staged wait vs the wrong-capture frames
+#
+# Verbatim, ordered field frame sequences from fixtures_1000ms_wrong_captures.md
+# where the OLD untyped wait captured a wrong frame, written ahead of the staged
+# wait that answers them. Each is replayed through session._notify during an
+# execute_operation staged wait. Frame classes:
+#   * bb0a / bb0b = 0xBB op-response (opcode 0x0a unlock / 0x0b lock+securemode)
+#   * bb02        = 0xBB 0x02 settled GETSTATUS status push
+#   * aa0a / aa0b = 0xAA acknowledgment matching the written opcode
+# byte[3] checksums are valid as captured, so the frames are fed unchanged.
+# =========================================================================== #
+@pytest.mark.asyncio
+async def test_replay_incident1_force_lock_ignores_prev_unlock_stale_bb0a() -> None:
+    """Incident 1: a force_lock wait ignores the previous unlock's stale bb0a.
+
+    The old untyped wait was satisfied by bb0a003b..., the delayed op-response
+    (opcode 0x0a = unlock) of the PRECEDING force_unlock, a leftover frame, not
+    an answer to this force_lock (opcode 0x0b). The typed wait keeps it on the
+    state-callback path and completes only on this force_lock's own bb0b.
+    """
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_command(Commands.LOCK)  # force_lock: opcode 0x0b
+
+    # Verbatim field frames (byte[3] checksums valid as captured).
+    stale_unlock_result = bytes.fromhex("bb0a003b0000000000000000000000000000")
+    settled_unlocked = bytes.fromhex("bb02003e0200000003000000000000000000")
+    true_lock_ack = bytes.fromhex("aa0b00490000000000000000000000000200")
+    genuine_lock_result = bytes.fromhex("bb0b003a0000000000000000000000000000")
+
+    op_task: asyncio.Task[bytes] | None = None
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # The previous unlock's stale op-response and a settled status push:
+        # neither is this force_lock's ack or op-response.
+        session._notify(0, bytearray(stale_unlock_result))
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert op_task is not None and not op_task.done()  # wrong frame ignored
+        # The genuine LOCK ack (opcode 0x0b, op byte 0x00) advances to stage 2.
+        session._notify(0, bytearray(true_lock_ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # Only its own bb0b op-response completes the wait.
+        session._notify(0, bytearray(genuine_lock_result))
+
+    feeder = asyncio.create_task(feed())
+    op_task = asyncio.create_task(
+        session.execute_operation(
+            command,
+            "force_lock",
+            ack_matcher=_ack_matcher(Commands.LOCK, 0x00),
+            response_matcher=_operation_response_matcher(Commands.LOCK),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    )
+    result = await op_task
+    await feeder
+
+    assert result == genuine_lock_result
+    # It went through the real ack stage; the stale bb0a did not short-circuit.
+    assert progress.acknowledged is True
+    # The stale op-response and the settle stayed on the state-callback path.
+    assert stale_unlock_result in seen
+    assert settled_unlocked in seen
+
+
+@pytest.mark.asyncio
+async def test_a_settled_status_push_completes_neither_operation_stage() -> None:
+    """A settled status push answers neither stage of an unlock's staged wait.
+
+    A GETSTATUS status push (0xBB 0x02) is not an operation frame, so it
+    answers neither the acknowledgment stage nor the op-response stage. Only
+    the unlock's own bb0a completes the wait.
+    """
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_command(Commands.UNLOCK)  # force_unlock: opcode 0x0a
+
+    # Verbatim field frames (byte[3] checksums valid as captured).
+    settled_unlocked = bytes.fromhex("bb02003e0200000003000000000000000000")
+    true_unlock_ack = bytes.fromhex("aa0a004a0000000000000000000000000200")
+    genuine_unlock_result = bytes.fromhex("bb0a003b0000000000000000000000000000")
+
+    op_task: asyncio.Task[bytes] | None = None
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # A settled status push during the ack stage does not complete it.
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert op_task is not None and not op_task.done()
+        session._notify(0, bytearray(true_unlock_ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # A settled status push during the op-response stage does not either.
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert not op_task.done()
+        session._notify(0, bytearray(genuine_unlock_result))
+
+    feeder = asyncio.create_task(feed())
+    op_task = asyncio.create_task(
+        session.execute_operation(
+            command,
+            "force_unlock",
+            ack_matcher=_ack_matcher(Commands.UNLOCK, 0x00),
+            response_matcher=_operation_response_matcher(Commands.UNLOCK),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    )
+    result = await op_task
+    await feeder
+
+    assert result == genuine_unlock_result
+    assert progress.acknowledged is True
+    # Both settled pushes stayed on the state-callback path, never claimed.
+    assert seen.count(settled_unlocked) == 2

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1106,7 +1106,7 @@ async def test_stage_deadlines_run_from_the_command_issue(
     op_response = _with_checksum(_OP_RESPONSE_OK)
 
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
 
     async def write_taking_half_a_second(*args: object, **kwargs: object) -> None:
         clock["now"] += 0.5
@@ -1213,7 +1213,7 @@ async def test_cooldown_paces_a_command_behind_the_last_frame(
     session, _ = _make_operation_session()
     session.enable_cooldown()
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
     session._last_callback_time = clock["now"] - 0.2
     slept: list[float] = []
 
@@ -1240,7 +1240,7 @@ async def test_execute_operation_pays_the_cooldown_before_its_write(
     session, client = _make_operation_session()
     session.enable_cooldown()
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
     session._last_callback_time = clock["now"] - 0.2
     slept: list[float] = []
     real_sleep = asyncio.sleep
@@ -1434,13 +1434,16 @@ async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
         # Wait for the op-response stage to arm its own timer, so the blocking
         # sleep below expires that timer and not the acknowledgment stage's.
         await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        # Key the schedule to the armed stage-2 budget, so the ordering
+        # holds however long the run spent getting here.
+        armed = op_wait_timeouts[1]
         loop = asyncio.get_running_loop()
-        loop.call_later(0.05, session._notify, 0, bytearray(op_response))
+        loop.call_later(armed / 4, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the notify handle
         # (the earlier deadline) and the stage-2 timeout handle run in the
         # same iteration, notify first, reproducing the race. The blocking
         # sleep is the point, so the async lint rule is suppressed.
-        time.sleep(0.4)  # noqa: ASYNC251
+        time.sleep(armed + 0.1)  # noqa: ASYNC251
 
     feeder = asyncio.create_task(feed())
     result = await session.execute_operation(
@@ -1491,14 +1494,17 @@ async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
         # Wait for the op-response stage to arm its own timer, so the blocking
         # sleep below expires that timer and not the acknowledgment stage's.
         await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        # Key the schedule to the armed stage-2 budget, so the ordering
+        # holds however long the run spent getting here.
+        armed = op_wait_timeouts[1]
         loop = asyncio.get_running_loop()
-        loop.call_later(0.25, session._notify, 0, bytearray(op_response))
+        loop.call_later(armed + 0.05, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the stage-2
         # timeout handle (the earlier deadline) and the notify handle run in
         # the same iteration, the timeout first, which is the ordering this
         # test pins. The blocking sleep is the point, so the async lint rule
         # is suppressed.
-        time.sleep(0.4)  # noqa: ASYNC251
+        time.sleep(armed + 0.15)  # noqa: ASYNC251
 
     feeder = asyncio.create_task(feed())
     result = await session.execute_operation(
@@ -1744,10 +1750,10 @@ async def test_execute_operation_generic_bleak_error_is_reraised() -> None:
 # =========================================================================== #
 # 1000 ms field replays: the typed staged wait vs the wrong-capture frames
 #
-# Verbatim, ordered field frame sequences from fixtures_1000ms_wrong_captures.md
-# where the OLD untyped wait captured a wrong frame, written ahead of the staged
-# wait that answers them. Each is replayed through session._notify during an
-# execute_operation staged wait. Frame classes:
+# Verbatim, ordered field frame sequences in which the OLD untyped wait
+# captured a wrong frame, written ahead of the staged wait that answers them.
+# Each is replayed through session._notify during an execute_operation staged
+# wait. Frame classes:
 #   * bb0a / bb0b = 0xBB op-response (opcode 0x0a unlock / 0x0b lock+securemode)
 #   * bb02        = 0xBB 0x02 settled GETSTATUS status push
 #   * aa0a / aa0b = 0xAA acknowledgment matching the written opcode

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1442,6 +1442,9 @@ async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
         # Key the schedule to the armed stage-2 budget, so the ordering
         # holds however long the run spent getting here.
         armed = op_wait_timeouts[1]
+        # armed == 0 would put the notify and the timeout on one deadline,
+        # decided by scheduling order; a stalled run must fail as stalled.
+        assert armed > 0, "the fixture stalled past the stage-2 budget"
         loop = asyncio.get_running_loop()
         loop.call_later(armed / 4, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the notify handle
@@ -1502,6 +1505,9 @@ async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
         # Key the schedule to the armed stage-2 budget, so the ordering
         # holds however long the run spent getting here.
         armed = op_wait_timeouts[1]
+        # armed == 0 would put the notify and the timeout on one deadline,
+        # decided by scheduling order; a stalled run must fail as stalled.
+        assert armed > 0, "the fixture stalled past the stage-2 budget"
         loop = asyncio.get_running_loop()
         loop.call_later(armed + 0.05, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the stage-2

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -963,14 +963,17 @@ async def test_execute_operation_op_response_before_ack() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
+async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """A previous same-opcode command's late op-response is taken as the answer.
 
     An op-response is matched on the opcode alone, so a fresh wait cannot
     tell its own answer from the previous same-opcode command's late one:
     fed during stage 1, the stale frame completes the wait through the
     supersede branch. progress.acknowledged staying False is the tell that
-    the result may not be this command's.
+    the result may not be this command's, and the completion is logged at
+    info so the case is visible in a field log.
     """
     session, client = _make_operation_session()
     progress = OperationProgress()
@@ -984,18 +987,20 @@ async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
         session._notify(0, bytearray(stale_op_response))
 
     feeder = asyncio.create_task(feed())
-    result = await session.execute_operation(
-        command,
-        "force_securemode",
-        ack_matcher=_ack_matcher(0x0B, 0x04),
-        response_matcher=_operation_response_matcher(0x0B),
-        response_timeout=5.0,
-        progress=progress,
-    )
+    with caplog.at_level("INFO", logger="yalexs_ble.session"):
+        result = await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
     await feeder
 
     assert result == bytes(stale_op_response)
     assert progress.acknowledged is False
+    assert "completed on its op-response; no acknowledgment was received" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A mechanical command is answered twice: an initial acknowledgment of the request, then an operation response when the motor stops, carrying the result. The session only ever waited for the first frame, so a command was reported complete while the motor was still moving, whatever the outcome. The traces and measurements are in #357.

`execute_operation` runs the wait in two typed stages against the command's own bytes and returns the operation response. The acknowledgment matcher keys on the written opcode and operation byte, which is what tells a secure-mode acknowledgment from a plain lock's on the shared Lock opcode; the operation-response matcher keys on the opcode alone, since an operation response carries no operation byte. Failures before the acknowledgment keep their retryable types, so a retrying caller re-sends early. After it the motor may be moving, so a timeout or a disconnect raises the new `OperationIncompleteError`, a `YaleXSBLEError` the package now exports, which ends the retry attempts and leaves the caller to decide from the `OperationProgress` record, with the result unknown.

Nothing in the library calls `execute_operation` yet; the callers arrive with the next part, so this change cannot alter any consumer's behaviour.

Testing: the load-bearing pair is `test_execute_operation_disconnect_after_ack_is_operation_incomplete` and `test_execute_operation_disconnect_before_ack_stays_retryable`, which pin the retryability boundary at the acknowledgment; without them the boundary could drift to either side and the suite would stay green. The rest of the session suite drives both stages through foreign, corrupt, and repeated frames, a stale operation response from a previous command of the same opcode, and deadlines measured from the command issue, and the matcher tests in the lock suite pin both matchers byte by byte.

The first of eight parts implementing #369.
