### PR TITLE
feat: add the momentary open (unlatch) operation

### DIFF
--- a/src/yalexs_ble/__init__.py
+++ b/src/yalexs_ble/__init__.py
@@ -11,7 +11,12 @@ from .const import (
 )
 from .lock import Lock
 from .push import PushLock
-from .session import AuthError, DisconnectedError, YaleXSBLEError
+from .session import (
+    AuthError,
+    DisconnectedError,
+    OperationIncompleteError,
+    YaleXSBLEError,
+)
 from .util import (
     ValidatedLockConfig,
     local_name_is_unique,
@@ -33,6 +38,7 @@ __all__ = [
     "LockInfo",
     "LockState",
     "LockStatus",
+    "OperationIncompleteError",
     "PushLock",
     "ValidatedLockConfig",
     "YaleXSBLEDiscovery",

--- a/src/yalexs_ble/__init__.py
+++ b/src/yalexs_ble/__init__.py
@@ -1,6 +1,7 @@
 from bleak_retry_connector import close_stale_connections_by_address
 
 from .const import (
+    MANUAL_INTERVENTION_STATUSES,
     AutoLockMode,
     ConnectionInfo,
     DoorStatus,
@@ -29,6 +30,7 @@ from .util import (
 __version__ = "4.0.5"
 
 __all__ = [
+    "MANUAL_INTERVENTION_STATUSES",
     "AuthError",
     "AutoLockMode",
     "ConnectionInfo",

--- a/src/yalexs_ble/__init__.py
+++ b/src/yalexs_ble/__init__.py
@@ -16,6 +16,7 @@ from .session import (
     AuthError,
     DisconnectedError,
     OperationIncompleteError,
+    UnlatchError,
     YaleXSBLEError,
 )
 from .util import (
@@ -42,6 +43,7 @@ __all__ = [
     "LockStatus",
     "OperationIncompleteError",
     "PushLock",
+    "UnlatchError",
     "ValidatedLockConfig",
     "YaleXSBLEDiscovery",
     "YaleXSBLEError",

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -118,12 +118,20 @@ class LockStatus(Enum):
     LOCKED = 0x05
     UNKNOWN_06 = 0x06  # PolDiscovery
     JAMMED = 0x07  # STATICPOSITION
-    # UNLATCHING = 0x09
-    # UNLATCHED = 0x0A
+    UNLATCHING = 0x09
+    UNLATCHED = 0x0A
     SECUREMODE = 0x0C
 
 
 VALUE_TO_LOCK_STATUS = {status.value: status for status in LockStatus}
+
+# Statuses reported during calibration (0x01) and polarity discovery (0x06),
+# setup conditions that end at the lock by hand.
+SETUP_CONDITION_STATUSES = frozenset({LockStatus.UNKNOWN_01, LockStatus.UNKNOWN_06})
+
+# Statuses that need a person at the lock. Exported so consumers do not
+# keep their own copy.
+MANUAL_INTERVENTION_STATUSES = SETUP_CONDITION_STATUSES | {LockStatus.JAMMED}
 
 
 class DoorStatus(Enum):

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -123,16 +123,12 @@ class LockStatus(Enum):
     SECUREMODE = 0x0C
     # Library-synthesized securing transitional. securemode() stamps it as
     # the operation's pending state and _project_lock_status consumes it,
-    # so it never reaches a published LockState.
-    SECURING = 0x12
+    # so it never reaches a published LockState. The value is wider than a
+    # byte, so no frame can decode to it either.
+    SECURING = 0x100
 
 
-# SECURING is excluded so it can never be decoded from a frame: a frame
-# carrying its value takes the unrecognized-code path instead of forging
-# the securing stamp.
-VALUE_TO_LOCK_STATUS = {
-    status.value: status for status in LockStatus if status is not LockStatus.SECURING
-}
+VALUE_TO_LOCK_STATUS = {status.value: status for status in LockStatus}
 
 # Statuses reported during calibration (0x01) and polarity discovery (0x06),
 # setup conditions that end at the lock by hand.

--- a/src/yalexs_ble/const.py
+++ b/src/yalexs_ble/const.py
@@ -121,9 +121,18 @@ class LockStatus(Enum):
     UNLATCHING = 0x09
     UNLATCHED = 0x0A
     SECUREMODE = 0x0C
+    # Library-synthesized securing transitional. securemode() stamps it as
+    # the operation's pending state and _project_lock_status consumes it,
+    # so it never reaches a published LockState.
+    SECURING = 0x12
 
 
-VALUE_TO_LOCK_STATUS = {status.value: status for status in LockStatus}
+# SECURING is excluded so it can never be decoded from a frame: a frame
+# carrying its value takes the unrecognized-code path instead of forging
+# the securing stamp.
+VALUE_TO_LOCK_STATUS = {
+    status.value: status for status in LockStatus if status is not LockStatus.SECURING
+}
 
 # Statuses reported during calibration (0x01) and polarity discovery (0x06),
 # setup conditions that end at the lock by hand.
@@ -183,6 +192,10 @@ class LockState:
     # Hold the previous auto lock state so that it can be restored if auto lock
     # is enabled
     auto_lock_prev: AutoLockState | None
+    # The secure lock, whose locked position is Secured alone. It is projected
+    # from the same reported status as lock (see _project_lock_status), so it
+    # carries its own transitionals and never takes the value SECUREMODE.
+    secure: LockStatus = LockStatus.UNKNOWN
 
 
 LockStateValue = LockStatus | DoorStatus | BatteryState | AutoLockState

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -44,11 +44,21 @@ from .const import (
     StatusType,
 )
 from .secure_session import SecureSession
-from .session import AuthError, DisconnectedError, Session, YaleXSBLEError
+from .session import (
+    OPERATION_RESPONSE_TIMEOUT,
+    AuthError,
+    DisconnectedError,
+    OperationProgress,
+    Session,
+    YaleXSBLEError,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 LOCK_INFO_TIMEOUT = 3
+
+# byte[4] of a Lock command: 0x04 turns the plain lock into securemode.
+SECUREMODE_OPERATION_BYTE = 0x04
 
 AA_BATTERY_VOLTAGE_TO_PERCENTAGE = (
     (1.55, 100),
@@ -354,10 +364,10 @@ class Lock:
                 if state[4] == SettingType.AUTOLOCK.value:
                     return [self._parse_auto_lock_state(state)]
         elif state[0] == 0xAA:
-            if state[1] == Commands.UNLOCK.value:
-                return [LockStatus.UNLOCKED]
-            if state[1] == Commands.LOCK.value:
-                return [LockStatus.LOCKED]
+            if state[1] in (Commands.UNLOCK.value, Commands.LOCK.value):
+                # Operation acknowledgment: byte[1] matches the command and
+                # the frame carries no result and no state.
+                return ()
             if state[1] in (
                 Commands.READSETTING.value,
                 Commands.WRITESETTING.value,
@@ -482,14 +492,41 @@ class Lock:
         )
         return self._lock_info
 
+    async def _execute_operation_command(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+    ) -> None:
+        """Run a mechanical operation, returning when the lock reports it done.
+
+        The acknowledgment and op-response matchers take their expected
+        bytes from the command here, before the session encrypts the buffer
+        in place.
+        """
+        assert self.session is not None  # nosec
+        opcode = command[0x01]
+        operation_byte = command[0x04]
+        await self.session.execute_operation(
+            command,
+            command_name,
+            ack_matcher=_ack_matcher(opcode, operation_byte),
+            response_matcher=_operation_response_matcher(opcode),
+            response_timeout=response_timeout,
+            progress=OperationProgress(),
+        )
+
     @raise_if_not_connected
     async def force_securemode(self) -> None:
         """Force the lock into securemode."""
         _LOGGER.debug("%s: Securing", self.name)
         assert self.session is not None  # nosec
-        await self.session.execute(
-            self.session.build_operation_command(Commands.LOCK, 0x04),
+        await self._execute_operation_command(
+            self.session.build_operation_command(
+                Commands.LOCK, SECUREMODE_OPERATION_BYTE
+            ),
             "force_securemode",
+            response_timeout=OPERATION_RESPONSE_TIMEOUT,
         )
         _LOGGER.debug("%s: Finished securemode", self.name)
 
@@ -498,8 +535,10 @@ class Lock:
         """Force the lock to lock."""
         _LOGGER.debug("%s: Locking", self.name)
         assert self.session is not None  # nosec
-        await self.session.execute(
-            self.session.build_command(Commands.LOCK), "force_lock"
+        await self._execute_operation_command(
+            self.session.build_command(Commands.LOCK),
+            "force_lock",
+            response_timeout=OPERATION_RESPONSE_TIMEOUT,
         )
         _LOGGER.debug("%s: Finished locking", self.name)
 
@@ -508,8 +547,10 @@ class Lock:
         """Force the lock to unlock."""
         _LOGGER.debug("%s: Unlocking", self.name)
         assert self.session is not None  # nosec
-        await self.session.execute(
-            self.session.build_command(Commands.UNLOCK), "force_unlock"
+        await self._execute_operation_command(
+            self.session.build_command(Commands.UNLOCK),
+            "force_unlock",
+            response_timeout=OPERATION_RESPONSE_TIMEOUT,
         )
         _LOGGER.debug("%s: Finished unlocking", self.name)
 

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -169,6 +169,38 @@ def _poll_response_matcher(
     return matches
 
 
+def _ack_matcher(opcode: int, operation_byte: int) -> Callable[[bytes], bool]:
+    """Match the acknowledgment of the written command.
+
+    The acknowledgment carries the operation byte the command was sent
+    with, which is what tells a securemode acknowledgment from a plain
+    lock's on the shared Lock opcode. An op-response carries 0x00 there
+    whatever the operation, which is why _operation_response_matcher
+    matches the opcode alone.
+    """
+
+    def _matches(data: bytes) -> bool:
+        return (
+            len(data) > 0x04
+            and data[0] == 0xAA
+            and data[1] == opcode
+            and data[4] == operation_byte
+        )
+
+    return _matches
+
+
+def _operation_response_matcher(opcode: int) -> Callable[[bytes], bool]:
+    """Match the op-response (0xBB + the sent opcode), emitted when the
+    motor stops.
+    """
+
+    def _matches(data: bytes) -> bool:
+        return len(data) > 0x0F and data[0] == 0xBB and data[1] == opcode
+
+    return _matches
+
+
 class Lock:
     def __init__(
         self,

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -593,6 +593,10 @@ class Lock:
         The Unlock opcode with operation byte 0x0A (there is no dedicated
         unlatch opcode); its op-response is a normal Unlock (0xBB 0A) frame.
 
+        The op-response answers the latch pull: the dwell and the latch's
+        return run after it, so returning here does not mean the cycle has
+        finished.
+
         A repeated unlatch fires the latch again, opening the door again, so
         once the command write has been ATTEMPTED no failure may re-send it: a
         write call that errors can still have delivered the request (the PDU
@@ -692,8 +696,8 @@ class Lock:
             await self.force_unlock()
 
     async def unlatch(self) -> None:
-        """Unlatch; this always runs the operation, since a momentary
-        action leaves no state a status read could test.
+        """Unlatch; this always runs the operation, since there is no
+        resting state to compare against.
         """
         await self.force_unlatch()
 

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -191,10 +191,12 @@ def _ack_matcher(opcode: int, operation_byte: int) -> Callable[[bytes], bool]:
 
     def _matches(data: bytes) -> bool:
         return (
+            # The floor covers the highest byte the match reads, the
+            # operation byte at 0x04.
             len(data) > 0x04
-            and data[0] == 0xAA
-            and data[1] == opcode
-            and data[4] == operation_byte
+            and data[0x00] == 0xAA
+            and data[0x01] == opcode
+            and data[0x04] == operation_byte
         )
 
     return _matches
@@ -206,7 +208,10 @@ def _operation_response_matcher(opcode: int) -> Callable[[bytes], bool]:
     """
 
     def _matches(data: bytes) -> bool:
-        return len(data) > 0x0F and data[0] == 0xBB and data[1] == opcode
+        # The match reads only the identity bytes, but the wait it completes
+        # reads the result at byte 0x0F, so the floor admits only a frame
+        # that carries it.
+        return len(data) > 0x0F and data[0x00] == 0xBB and data[0x01] == opcode
 
     return _matches
 

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -46,10 +46,13 @@ from .const import (
 from .secure_session import SecureSession
 from .session import (
     OPERATION_RESPONSE_TIMEOUT,
+    UNLATCH_OPERATION_RESPONSE_TIMEOUT,
     AuthError,
     DisconnectedError,
+    OperationIncompleteError,
     OperationProgress,
     Session,
+    UnlatchError,
     YaleXSBLEError,
 )
 
@@ -57,7 +60,9 @@ _LOGGER = logging.getLogger(__name__)
 
 LOCK_INFO_TIMEOUT = 3
 
-# byte[4] of a Lock command: 0x04 turns the plain lock into securemode.
+# byte[4] of an operation command selects the variant: 0x0A on Unlock is an
+# unlatch (retract the latch), 0x04 on Lock is securemode.
+UNLATCH_OPERATION_BYTE = 0x0A
 SECUREMODE_OPERATION_BYTE = 0x04
 
 AA_BATTERY_VOLTAGE_TO_PERCENTAGE = (
@@ -502,7 +507,9 @@ class Lock:
         command: bytearray,
         command_name: str,
         response_timeout: float,
+        progress: OperationProgress | None = None,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> None:
         """Run a mechanical operation, returning when the lock reports it done.
 
@@ -513,14 +520,21 @@ class Lock:
         assert self.session is not None  # nosec
         opcode = command[0x01]
         operation_byte = command[0x04]
+        if progress is None:
+            # Only the unlatch reads the record: write_attempted gates its
+            # never-re-send conversion. Lock, unlock and securemode convert
+            # nothing on it, so they let the callee own a throwaway rather
+            # than push the construction into three call sites.
+            progress = OperationProgress()
         await self.session.execute_operation(
             command,
             command_name,
             ack_matcher=_ack_matcher(opcode, operation_byte),
             response_matcher=_operation_response_matcher(opcode),
             response_timeout=response_timeout,
-            progress=OperationProgress(),
+            progress=progress,
             write_success_callback=write_success_callback,
+            wait_for_ack=wait_for_ack,
         )
 
     @raise_if_not_connected
@@ -569,6 +583,61 @@ class Lock:
             write_success_callback=write_success_callback,
         )
         _LOGGER.debug("%s: Finished unlocking", self.name)
+
+    @raise_if_not_connected
+    async def force_unlatch(
+        self, write_success_callback: Callable[[], None] | None = None
+    ) -> None:
+        """Force the lock to unlatch (momentary "open door" / retract the latch).
+
+        The Unlock opcode with operation byte 0x0A (there is no dedicated
+        unlatch opcode); its op-response is a normal Unlock (0xBB 0A) frame.
+
+        A repeated unlatch fires the latch again, opening the door again, so
+        once the command write has been ATTEMPTED no failure may re-send it: a
+        write call that errors can still have delivered the request (the PDU
+        leaves the radio and only the ATT response is lost), so every failure
+        from the write attempt onward converts to the non-retryable
+        UnlatchError (OperationIncompleteError, already non-retryable,
+        propagates as itself). Failures before the write attempt (connect,
+        session setup, encryption) stay retryable.
+
+        That same rule makes the acknowledgment a don't care here, so this is
+        the one operation that waits on its op-response alone.
+        """
+        _LOGGER.debug("%s: Unlatching", self.name)
+        assert self.session is not None  # nosec
+        progress = OperationProgress()
+        try:
+            await self._execute_operation_command(
+                self.session.build_operation_command(
+                    Commands.UNLOCK, UNLATCH_OPERATION_BYTE
+                ),
+                "force_unlatch",
+                response_timeout=UNLATCH_OPERATION_RESPONSE_TIMEOUT,
+                progress=progress,
+                write_success_callback=write_success_callback,
+                wait_for_ack=False,
+            )
+        except OperationIncompleteError:
+            # Already non-retryable: the result never arrived. Ordered ahead
+            # of the broad clause below so the type reaches the caller
+            # unwrapped.
+            raise
+        except Exception as err:
+            # Broad on purpose: no failure of any kind may reach the retry
+            # wrapper once the write was attempted. Every path re-raises;
+            # cancellation is a BaseException and passes through. AuthError
+            # is converted too, so auth failure handling waits for the next
+            # update cycle.
+            if progress.write_attempted:
+                raise UnlatchError(
+                    f"{self.name}: Unlatch failed after the command write was "
+                    f"attempted, and a repeated unlatch opens the door again, "
+                    f"so it was not retried: {err}"
+                ) from err
+            raise
+        _LOGGER.debug("%s: Finished unlatching", self.name)
 
     @raise_if_not_connected
     async def set_auto_lock(self, mode: AutoLockMode, duration: int) -> None:
@@ -621,6 +690,12 @@ class Lock:
     async def unlock(self) -> None:
         if (await self.lock_status()) != LockStatus.UNLOCKED:
             await self.force_unlock()
+
+    async def unlatch(self) -> None:
+        """Unlatch; this always runs the operation, since a momentary
+        action leaves no state a status read could test.
+        """
+        await self.force_unlatch()
 
     async def _execute_command(
         self,

--- a/src/yalexs_ble/lock.py
+++ b/src/yalexs_ble/lock.py
@@ -502,6 +502,7 @@ class Lock:
         command: bytearray,
         command_name: str,
         response_timeout: float,
+        write_success_callback: Callable[[], None] | None = None,
     ) -> None:
         """Run a mechanical operation, returning when the lock reports it done.
 
@@ -519,10 +520,13 @@ class Lock:
             response_matcher=_operation_response_matcher(opcode),
             response_timeout=response_timeout,
             progress=OperationProgress(),
+            write_success_callback=write_success_callback,
         )
 
     @raise_if_not_connected
-    async def force_securemode(self) -> None:
+    async def force_securemode(
+        self, write_success_callback: Callable[[], None] | None = None
+    ) -> None:
         """Force the lock into securemode."""
         _LOGGER.debug("%s: Securing", self.name)
         assert self.session is not None  # nosec
@@ -532,11 +536,14 @@ class Lock:
             ),
             "force_securemode",
             response_timeout=OPERATION_RESPONSE_TIMEOUT,
+            write_success_callback=write_success_callback,
         )
         _LOGGER.debug("%s: Finished securemode", self.name)
 
     @raise_if_not_connected
-    async def force_lock(self) -> None:
+    async def force_lock(
+        self, write_success_callback: Callable[[], None] | None = None
+    ) -> None:
         """Force the lock to lock."""
         _LOGGER.debug("%s: Locking", self.name)
         assert self.session is not None  # nosec
@@ -544,11 +551,14 @@ class Lock:
             self.session.build_command(Commands.LOCK),
             "force_lock",
             response_timeout=OPERATION_RESPONSE_TIMEOUT,
+            write_success_callback=write_success_callback,
         )
         _LOGGER.debug("%s: Finished locking", self.name)
 
     @raise_if_not_connected
-    async def force_unlock(self) -> None:
+    async def force_unlock(
+        self, write_success_callback: Callable[[], None] | None = None
+    ) -> None:
         """Force the lock to unlock."""
         _LOGGER.debug("%s: Unlocking", self.name)
         assert self.session is not None  # nosec
@@ -556,6 +566,7 @@ class Lock:
             self.session.build_command(Commands.UNLOCK),
             "force_unlock",
             response_timeout=OPERATION_RESPONSE_TIMEOUT,
+            write_success_callback=write_success_callback,
         )
         _LOGGER.debug("%s: Finished unlocking", self.name)
 

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -25,6 +25,8 @@ from .const import (
     APPLE_MFR_ID,
     HAP_ENCRYPTED_FIRST_BYTE,
     HAP_FIRST_BYTE,
+    MANUAL_INTERVENTION_STATUSES,
+    SETUP_CONDITION_STATUSES,
     YALE_MFR_ID,
     AuthState,
     AutoLockMode,
@@ -36,7 +38,6 @@ from .const import (
     LockState,
     LockStateValue,
     LockStatus,
-    OperationError,
 )
 from .lock import Lock
 from .session import (
@@ -44,6 +45,7 @@ from .session import (
     BluetoothError,
     DisconnectedError,
     NoAdvertisementError,
+    OperationIncompleteError,
     ResponseError,
     YaleXSBLEError,
 )
@@ -121,6 +123,23 @@ DEADLINE_WAKEUP_RETRY_DELAY = 1.0
 # How long to wait if we get an update storm from the lock
 UPDATE_IN_PROGRESS_DEFER_SECONDS = DISCONNECT_DELAY - 1
 
+# Statuses that report a position the lock is holding; the setup conditions
+# qualify because they end only by hand. Any other status needs the
+# follow-up lock_status() poll to replace it, so it must not enter
+# _seen_this_session, which would suppress that poll. An unlisted status
+# therefore costs a poll, not a stuck display. _finalize_operation reads the
+# set a second time to pick the delay for that poll.
+POSITION_READINGS = frozenset(
+    {
+        LockStatus.LOCKED,
+        LockStatus.UNLOCKED,
+        LockStatus.SECUREMODE,
+        LockStatus.JAMMED,
+        LockStatus.UNKNOWN_01,
+        LockStatus.UNKNOWN_06,
+    }
+)
+
 RETRY_BACKOFF_EXCEPTIONS = (BleakDBusError, DisconnectedError)
 
 RETRY_EXCEPTIONS = (ResponseError, *BLEAK_RETRY_EXCEPTIONS)
@@ -179,10 +198,6 @@ NO_BATTERY_SUPPORT_MODELS = {
 }
 
 AUTO_LOCK_DEFAULT_DURATION = 90
-
-# Statuses reported during calibration (0x01) and polarity discovery (0x06),
-# setup conditions that end at the lock by hand.
-SETUP_CONDITION_STATUSES = {LockStatus.UNKNOWN_01, LockStatus.UNKNOWN_06}
 
 
 def operation_lock(func: WrapFuncType) -> WrapFuncType:
@@ -304,6 +319,12 @@ def retry_bluetooth_connection_error(
 class PushLock:
     """A lock with push updates."""
 
+    # mypy takes the type of an attribute from its assignment, and
+    # _init_operation_state assigns these fields nothing but None, so without
+    # these declarations the inferred type would be None.
+    _pending_op_state: LockStatus | None
+    _operation_outcome: LockStatus | None
+
     def __init__(
         self,
         local_name: str | None = None,
@@ -356,7 +377,24 @@ class PushLock:
         self._next_disconnect_delay = idle_disconnect_delay
         self._first_update_future: asyncio.Future[None] | None = None
         self._background_tasks: set[asyncio.Task[None]] = set()
-        self._last_lock_operation_complete_time = NEVER_TIME
+        self._init_operation_state()
+        # A status needing someone at the lock that the window filter dropped,
+        # kept until the operation can apply it. The status itself, not a flag,
+        # so the operation applies the one the lock reported rather than a
+        # stand-in for it. Survives a reconnect, since a mechanism needing
+        # attention outlives the link that reported it.
+        self._seen_intervention_status: LockStatus | None = None
+        # A scheduled status poll owes one lock_status() read that
+        # _seen_this_session may not suppress: the reading it holds can be the very
+        # one the poll exists to replace. Not reset on reconnect, since it is
+        # an obligation, not session state.
+        self._force_lock_status_poll = False
+        # Earliest moment an update cycle may read the lock. Every scheduled cycle is
+        # held to it, so a read cannot be taken while the reported state is
+        # still settling, whichever path scheduled the cycle and however short
+        # the debounce made it. Not reset on reconnect: a mechanism still
+        # moving does not care which link watches it.
+        self._earliest_update_time = NEVER_TIME
         self._last_operation_complete_time = NEVER_TIME
         self._always_connected = always_connected
         self._slow_params_set = False
@@ -694,29 +732,150 @@ class PushLock:
 
     async def securemode(self) -> None:
         """Set the lock into securemode."""
-        self._update_any_state([LockStatus.LOCKING])
-        self._cancel_future_update()
-        await self._execute_lock_operation(
+        await self._run_lock_operation(
             "force_securemode", LockStatus.LOCKING, LockStatus.SECUREMODE
         )
 
     async def lock(self) -> None:
         """Lock the lock."""
-        self._update_any_state([LockStatus.LOCKING])
-        self._cancel_future_update()
-        await self._execute_lock_operation(
+        await self._run_lock_operation(
             "force_lock", LockStatus.LOCKING, LockStatus.LOCKED
         )
 
     async def unlock(self) -> None:
         """Unlock the lock."""
-        self._update_any_state([LockStatus.UNLOCKING])
-        self._cancel_future_update()
-        await self._execute_lock_operation(
+        await self._run_lock_operation(
             "force_unlock", LockStatus.UNLOCKING, LockStatus.UNLOCKED
         )
 
+    def _init_operation_state(self) -> None:
+        """Initialize the per-operation fields.
+
+        The operation lock allows one operation at a time; these three
+        describe it. Each is set again as an operation reaches the point it
+        describes, so this only makes them readable before the first one.
+        """
+        self._pending_op_state = None
+        self._operation_outcome = None
+        self._operation_window_open = False
+
     @operation_lock
+    async def _run_lock_operation(
+        self, op_attr: str, pending_state: LockStatus, complete_state: LockStatus
+    ) -> None:
+        """Run a lock operation; _finalize_operation runs on every exit.
+
+        The common body of lock(), unlock() and securemode(); it drives the
+        operation and leaves the display with the result, and failures raise
+        to the caller.
+        """
+        self._cancel_future_update()
+        self._operation_outcome = None
+        try:
+            await self._execute_lock_operation(op_attr, pending_state, complete_state)
+        except Exception:
+            if self._operation_outcome is None:
+                self._operation_outcome = LockStatus.UNKNOWN
+            raise
+        finally:
+            self._finalize_operation()
+
+    def _operation_write_success(self) -> None:
+        """The command write reached the lock: the single state-action moment.
+
+        Order matters: stamp the operation's transitional while the window is
+        still closed, so the stamp passes the filter, then open the window.
+
+        Clearing _seen_intervention_status is a backstop, so no record
+        reaches a new command's write-success. A record that did reach here
+        would be superseded anyway: the command a caller issued after it is the
+        intervention the status calls for, and its outcome is the newer truth.
+        """
+        self._seen_intervention_status = None
+        if self._pending_op_state is not None:
+            # The None check only narrows the type; every caller is inside
+            # an operation that set it.
+            self._update_any_state([self._pending_op_state], arm_resync=False)
+        self._operation_window_open = True
+
+    def _close_operation_window(self) -> None:
+        """Close the operation window and drop everything it recorded.
+
+        Clearing _seen_intervention_status here means the record cannot
+        outlive the window; _finalize_operation reads it first, and the retry
+        path only gets here with it already clear.
+        """
+        self._operation_window_open = False
+        self._pending_op_state = None
+        self._seen_intervention_status = None
+
+    def _finalize_operation(self) -> None:
+        """Close the operation window, display the outcome, schedule the next poll.
+
+        Runs on every exit of _run_lock_operation, cancellation included: a
+        window left open would freeze the display on the operation's
+        transitional state.
+        """
+        outcome = self._operation_outcome
+        # A jam or setup condition recorded while the window was open is the
+        # lock's own reading and may never be sent again, so it replaces the
+        # outcome.
+        if (recorded := self._seen_intervention_status) is not None:
+            outcome = recorded
+            _LOGGER.debug(
+                "%s: the lock reported %s while the operation was in flight; "
+                "displaying it",
+                self.name,
+                recorded,
+            )
+        self._close_operation_window()
+        if not self._running:
+            # The watcher was stopped while this operation was in flight. The
+            # window is closed above so the object is left consistent, but
+            # scheduling a cycle now would arm a timer holding the lock past the
+            # stop, with nothing left to run it and no consumer listening.
+            return
+        if outcome is not None:
+            self._update_any_state([outcome], arm_resync=False)
+        self._force_lock_status_poll = True
+        self._earliest_update_time = time.monotonic() + LOCK_STALE_STATE_DEBOUNCE_DELAY
+        # A settled status waits the keep-alive; an unsettled one polls at
+        # the stale-state debounce, the earliest a poll answers with the
+        # motor stopped.
+        if self.lock_status in POSITION_READINGS:
+            delay = KEEP_ALIVE_TIME
+        else:
+            delay = LOCK_STALE_STATE_DEBOUNCE_DELAY
+        self._schedule_future_update_with_debounce(delay)
+
+    def _admit_lock_status(
+        self, incoming: LockStatus, current: LockStatus
+    ) -> LockStatus:
+        """Decide the displayed lock status for an incoming value.
+
+        Every incoming lock status, polled or pushed, must pass through
+        here.
+        """
+        if self._operation_window_open:
+            # No received lock status is accepted between write-success and
+            # op-response; the operation applies its own outcome. Door and
+            # battery values in the same frame are unaffected.
+            if incoming in MANUAL_INTERVENTION_STATUSES:
+                # Recorded because it may never be sent again; the
+                # operation applies it at its exit. The last one recorded
+                # wins, and the follow-up status poll asks the lock again.
+                self._seen_intervention_status = incoming
+            _LOGGER.debug(
+                "%s: Operation in flight, not accepting lock status %s",
+                self.name,
+                incoming,
+            )
+            return current
+        return incoming
+
+    # The decorator retries only AuthError and RETRYABLE_EXCEPTIONS; the
+    # operation errors below leave on their first raise. The operation lock
+    # is already held by _run_lock_operation, the only caller.
     @retry_bluetooth_connection_error
     async def _execute_lock_operation(
         self, op_attr: str, pending_state: LockStatus, complete_state: LockStatus
@@ -727,44 +886,49 @@ class PushLock:
                 f"{self.name}: Lock operation not possible because not running"
             )
         _LOGGER.debug("%s: Starting %s", self.name, pending_state)
-        self._update_any_state([pending_state])
-        self._cancel_future_update()
+        # Re-set on every attempt: the transitional this attempt stamps at
+        # its write-success.
+        self._pending_op_state = pending_state
         try:
             lock = await self._ensure_connected()
             self._cancel_future_update()
-            await getattr(lock, op_attr)()
+            # The write-success hook is what stamps the transitional and
+            # opens the window, so only this operation can open one.
+            await getattr(lock, op_attr)(
+                write_success_callback=self._operation_write_success
+            )
+        except OperationIncompleteError:
+            # Listed so it reaches the caller as itself: the arm below
+            # would convert it while a status stands recorded.
+            _LOGGER.debug(
+                "%s: %s did not complete; the result never arrived",
+                self.name,
+                op_attr,
+            )
+            raise
         except Exception as ex:
-            self._update_any_state([LockStatus.UNKNOWN])
-            # The attempt ended here, so the stale-state debounce measures
-            # from this moment on a failure as it does on success.
-            self._last_lock_operation_complete_time = time.monotonic()
-            # The retry_bluetooth_connection_error wrapper calls
-            # _async_handle_disconnected for RETRY_EXCEPTIONS /
-            # RETRY_BACKOFF_EXCEPTIONS only; AuthError, BleakNotFoundError and
-            # any other exception propagate without disconnecting.
+            if (recorded := self._seen_intervention_status) is not None:
+                # A retry would drive the motor into a mechanism that needs
+                # attention, so end the attempts with a type outside the
+                # retry set; the result truly never arrived.
+                raise OperationIncompleteError(
+                    f"{self.name}: the lock reported {recorded} while "
+                    f"{op_attr} was in flight; the command was not re-sent "
+                    f"and the result is unknown"
+                ) from ex
+            # Close the window so the next attempt re-stamps at its
+            # write-success; _finalize_operation applies the outcome if none
+            # follows.
+            self._close_operation_window()
             _LOGGER.debug(
                 "%s: Failed to execute lock operation due to %s",
                 self.name,
                 ex,
             )
             raise
-        # A failure op-response was already parsed into JAMMED and published
-        # before this write, so the commanded state must not replace it. The
-        # guard is only needed while this part of #369 stands alone: the
-        # parts that follow rework this path to raise on a reported failure,
-        # and they remove it.
-        if lock._last_op_error in (None, OperationError.COMM_SUCCESS):
-            self._update_any_state([complete_state])
-            _LOGGER.debug("%s: Finished %s", self.name, complete_state)
-        else:
-            _LOGGER.debug(
-                "%s: the lock reported %s failed; the reported state stays on display",
-                self.name,
-                op_attr,
-            )
-        now = time.monotonic()
-        self._last_lock_operation_complete_time = now
-        self._complete_operation(now)
+        self._operation_outcome = complete_state
+        _LOGGER.debug("%s: Finished %s", self.name, complete_state)
+        self._complete_operation(time.monotonic())
 
     @property
     def auto_lock_durations(self) -> list[int]:
@@ -885,7 +1049,20 @@ class PushLock:
             self.auto_lock_prev,
         )
 
-    def _update_any_state(self, states: Iterable[LockStateValue | AuthState]) -> None:
+    def _update_any_state(
+        self,
+        states: Iterable[LockStateValue | AuthState],
+        arm_resync: bool = True,
+    ) -> None:
+        """Apply states to the display.
+
+        arm_resync is False for the states an operation applies itself. A
+        status change coming from the lock arms a resync cycle to read the
+        settled value back; a status the operation stamped needs no such read,
+        and arming one from inside an operation displaces the delay
+        _finalize_operation chooses when the operation ends. Those states are
+        read by the operation's own follow-up status poll instead.
+        """
         _LOGGER.debug("%s: State changed: %s", self.name, states)
         lock_state = self._get_current_state()
         original_lock_status = lock_state.lock
@@ -911,15 +1088,27 @@ class PushLock:
                 if lock_state.auth != state:
                     changes["auth"] = state
             elif isinstance(state, LockStatus):
-                if lock_state.lock != state:
-                    if state in SETUP_CONDITION_STATUSES:
+                # Route every incoming lock status through the policy before the
+                # equality check, so the admission filter is the single authority
+                # for the displayed value. A repeated identical reading is put
+                # through it too rather than short-circuited.
+                admitted = self._admit_lock_status(state, lock_state.lock)
+                if admitted not in POSITION_READINGS:
+                    # A display left on anything but a settled position must
+                    # not suppress the follow-up poll, so LockStatus is
+                    # removed from _seen_this_session. A refused reading
+                    # leaves the operation's transitional standing, so it
+                    # reaches here too.
+                    self._seen_this_session.discard(type(state))
+                if lock_state.lock != admitted:
+                    if admitted in SETUP_CONDITION_STATUSES:
                         _LOGGER.warning(
                             "%s: Lock reports %s, a setup condition that ends "
                             "at the lock by hand",
                             self.name,
-                            state,
+                            admitted,
                         )
-                    changes["lock"] = state
+                    changes["lock"] = admitted
             elif isinstance(state, DoorStatus):
                 if lock_state.door != state:
                     changes["door"] = state
@@ -949,7 +1138,8 @@ class PushLock:
 
         lock_state = replace(lock_state, **changes)
         if (
-            original_lock_status != lock_state.lock
+            arm_resync
+            and original_lock_status != lock_state.lock
             and (not lock_state.auth or lock_state.auth.successful)
             and original_lock_status != LockStatus.UNKNOWN
         ):
@@ -1209,11 +1399,19 @@ class PushLock:
         #
         # However, we always want to poll lock
         # state to keep the connection alive if we are always connected.
-        if LockStatus not in self._seen_this_session or (
-            not made_request and self._always_connected
+        #
+        # A poll scheduled after an operation asks regardless:
+        # _seen_this_session may hold the very reading it must replace.
+        if (
+            self._force_lock_status_poll
+            or LockStatus not in self._seen_this_session
+            or (not made_request and self._always_connected)
         ):
             made_request = True
             await lock.lock_status()
+            # Cleared only by a poll that answered; an earlier failure
+            # leaves the obligation to the retry.
+            self._force_lock_status_poll = False
             self._record_auth_success()
 
         _LOGGER.debug("%s: Finished update", self.name)
@@ -1490,7 +1688,14 @@ class PushLock:
         self._schedule_future_update(future_update_time)
 
     def _schedule_future_update(self, future_update_time: float) -> None:
-        """Schedule an update in future seconds."""
+        """Schedule an update in future seconds, never before _earliest_update_time.
+
+        Every arming path passes through here, including the ones that
+        shorten a request.
+        """
+        future_update_time = max(
+            future_update_time, self._earliest_update_time - time.monotonic()
+        )
         _LOGGER.debug(
             "%s: Scheduling update to happen in %s seconds",
             self.name,
@@ -1511,18 +1716,15 @@ class PushLock:
             )
             self._schedule_future_update_with_debounce(UPDATE_IN_PROGRESS_DEFER_SECONDS)
             return
-        if (
-            seconds_time_lock_op := (now - self._last_lock_operation_complete_time)
-        ) < LOCK_STALE_STATE_DEBOUNCE_DELAY:
+        if now < self._earliest_update_time:
+            # The floor moved after this cycle was armed; re-arm for the
+            # remainder. The fired timer is spent, so nothing coalesces.
             _LOGGER.debug("%s: Rescheduling update to avoid stale state", self.name)
-            self._schedule_future_update_with_debounce(seconds_time_lock_op)
+            self._schedule_future_update(self._earliest_update_time - now)
             return
         if self._operation_lock.locked():
-            # The debounce above is measured from the last operation to have
-            # finished, so an operation still running does not answer it. A
-            # cycle created here would wait on the operation lock and read the
-            # lock the instant that operation ended, inside the window the
-            # debounce exists to keep it out of. Check again shortly instead.
+            # The cycle is re-armed rather than created, so it does not sit
+            # on the operation lock and poll the instant the motor stops.
             _LOGGER.debug(
                 "%s: Rescheduling update until the operation lock is released",
                 self.name,

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -829,7 +829,10 @@ class PushLock:
         """The command write reached the lock: the single state-action moment.
 
         Order matters: stamp the operation's transitional while the window is
-        still closed, so the stamp passes the filter, then open the window.
+        still closed, so the stamp passes the filter. The window then opens in
+        a finally, because the session contains an exception from this hook
+        and runs the staged wait to its end: a stamp that raised must not
+        leave the whole operation running with the window closed.
 
         Clearing _seen_intervention_status is a backstop, so no record
         reaches a new command's write-success. A record that did reach here
@@ -837,11 +840,13 @@ class PushLock:
         intervention the status calls for, and its outcome is the newer truth.
         """
         self._seen_intervention_status = None
-        if self._pending_op_state is not None:
-            # The None check only narrows the type; every caller is inside
-            # an operation that set it.
-            self._update_any_state([self._pending_op_state], arm_resync=False)
-        self._operation_window_open = True
+        try:
+            if self._pending_op_state is not None:
+                # The None check only narrows the type; every caller is inside
+                # an operation that set it.
+                self._update_any_state([self._pending_op_state], arm_resync=False)
+        finally:
+            self._operation_window_open = True
 
     def _close_operation_window(self) -> None:
         """Close the operation window and drop everything it recorded.

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -800,11 +800,13 @@ class PushLock:
     async def unlatch(self) -> None:
         """Unlatch (momentarily open) the lock.
 
-        The op-response arrives after the latch has returned, so the
-        completed state is UNLOCKED, not UNLATCHED.
+        The op-response answers the latch pull, so the completed state is
+        UNLATCHED: the latch is retracted and the door lock is open. The
+        dwell and the latch's return run after it, and the state the lock
+        settles to arrives as a later status update.
         """
         await self._run_lock_operation(
-            "force_unlatch", LockStatus.UNLATCHING, LockStatus.UNLOCKED
+            "force_unlatch", LockStatus.UNLATCHING, LockStatus.UNLATCHED
         )
 
     def _init_operation_state(self) -> None:
@@ -906,9 +908,9 @@ class PushLock:
         if outcome is not None:
             self._update_any_state([outcome], arm_resync=False)
         # A settled pair waits the keep-alive; an unsettled one polls at
-        # the stale-state debounce, the earliest a poll answers with the
-        # motor stopped. The two motion values are the only transitional
-        # readings the projection publishes on the secure channel.
+        # the stale-state debounce. The two motion values are the only
+        # transitional readings the projection publishes on the secure
+        # channel.
         if self.lock_status in POSITION_READINGS and self.secure_status not in (
             LockStatus.LOCKING,
             LockStatus.UNLOCKING,

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -329,7 +329,10 @@ def _project_lock_status(
     status channel for the secure lock. To maintain backward compatibility
     the main lock keeps SECUREMODE as its settled secured position. The
     internal state SECURING is the equivalent of the main lock's LOCKING
-    state. The model has no Secured to Locked transition.
+    state. The model has no Secured to Locked transition, so a reported
+    LOCKING never animates the secure lock: only a reported SECUREMODE
+    proves the lock is secured, and the settled SECUREMODE that follows a
+    securing motion re-secures the display.
     """
     if reported is LockStatus.SECURING:
         # SECURING: if the main lock is already locked it stays locked.

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -112,6 +112,11 @@ SLOW_TIMEOUT = 600  # 6000ms (spec minimum here is (1 + 16) * 30ms * 2 = 1020ms)
 # How long to wait to query the lock after an operation to make sure its not jammed
 POST_OPERATION_SYNC_TIME = 10.00
 
+# How long to wait and check again while an operation is in flight: an
+# update cycle created then would run the instant the operation ends, while
+# the lock still reports a stale state.
+DEADLINE_WAKEUP_RETRY_DELAY = 1.0
+
 # How long to wait if we get an update storm from the lock
 UPDATE_IN_PROGRESS_DEFER_SECONDS = DISCONNECT_DELAY - 1
 
@@ -729,6 +734,9 @@ class PushLock:
             await getattr(lock, op_attr)()
         except Exception as ex:
             self._update_any_state([LockStatus.UNKNOWN])
+            # The attempt ended here, so the stale-state debounce measures
+            # from this moment on a failure as it does on success.
+            self._last_lock_operation_complete_time = time.monotonic()
             # The retry_bluetooth_connection_error wrapper calls
             # _async_handle_disconnected for RETRY_EXCEPTIONS /
             # RETRY_BACKOFF_EXCEPTIONS only; AuthError, BleakNotFoundError and
@@ -1495,6 +1503,18 @@ class PushLock:
         ) < LOCK_STALE_STATE_DEBOUNCE_DELAY:
             _LOGGER.debug("%s: Rescheduling update to avoid stale state", self.name)
             self._schedule_future_update_with_debounce(seconds_time_lock_op)
+            return
+        if self._operation_lock.locked():
+            # The debounce above is measured from the last operation to have
+            # finished, so an operation still running does not answer it. A
+            # cycle created here would wait on the operation lock and read the
+            # lock the instant that operation ended, inside the window the
+            # debounce exists to keep it out of. Check again shortly instead.
+            _LOGGER.debug(
+                "%s: Rescheduling update until the operation lock is released",
+                self.name,
+            )
+            self._schedule_future_update_with_debounce(DEADLINE_WAKEUP_RETRY_DELAY)
             return
         self._update_task = asyncio.create_task(self._execute_deferred_update())
 

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -873,12 +873,16 @@ class PushLock:
         if (recorded := self._seen_intervention_status) is not None:
             outcome = recorded
             _LOGGER.debug(
-                "%s: the lock reported %s while the operation was in flight; "
-                "displaying it",
+                "%s: the lock reported %s while the operation was in flight",
                 self.name,
                 recorded,
             )
         self._close_operation_window()
+        # Both describe the mechanism rather than the watcher, so both
+        # outlive a stop. Stamped before the stop check, so a watcher
+        # started again on this instance inherits them.
+        self._force_lock_status_poll = True
+        self._earliest_update_time = time.monotonic() + LOCK_STALE_STATE_DEBOUNCE_DELAY
         if not self._running:
             # The watcher was stopped while this operation was in flight. The
             # window is closed above so the object is left consistent, but
@@ -887,8 +891,6 @@ class PushLock:
             return
         if outcome is not None:
             self._update_any_state([outcome], arm_resync=False)
-        self._force_lock_status_poll = True
-        self._earliest_update_time = time.monotonic() + LOCK_STALE_STATE_DEBOUNCE_DELAY
         # A settled pair waits the keep-alive; an unsettled one polls at
         # the stale-state debounce, the earliest a poll answers with the
         # motor stopped. The two motion values are the only transitional

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -125,8 +125,10 @@ DEADLINE_WAKEUP_RETRY_DELAY = 1.0
 UPDATE_IN_PROGRESS_DEFER_SECONDS = DISCONNECT_DELAY - 1
 
 # Statuses that report a position the lock is holding; the setup conditions
-# qualify because they end only by hand. Any other status needs the
-# follow-up lock_status() poll to replace it, so it must not enter
+# qualify because they end only by hand, and UNLATCHED qualifies because it
+# is the end state of an unlatch, held until the dwell runs out, as UNLOCKED
+# may be ended by auto-lock. Any other status needs the follow-up
+# lock_status() poll to replace it, so it must not enter
 # _seen_this_session, which would suppress that poll. An unlisted status
 # therefore costs a poll, not a stuck display. _finalize_operation reads the
 # set a second time to pick the delay for that poll.
@@ -134,6 +136,7 @@ POSITION_READINGS = frozenset(
     {
         LockStatus.LOCKED,
         LockStatus.UNLOCKED,
+        LockStatus.UNLATCHED,
         LockStatus.SECUREMODE,
         LockStatus.JAMMED,
         LockStatus.UNKNOWN_01,

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -316,6 +316,46 @@ def retry_bluetooth_connection_error(
     return cast(WrapFuncType, _async_wrap_retry_bluetooth_connection_error)
 
 
+def _project_lock_status(
+    reported: LockStatus,
+    main: LockStatus,
+    secure: LockStatus,
+) -> tuple[LockStatus, LockStatus]:
+    """Project the physical lock's status onto the logical main and secure
+    lock statuses.
+
+    The physical lock maintains a single status, but to include the
+    transitional states for both logical locks we need an additional lock
+    status channel for the secure lock. To maintain backward compatibility
+    the main lock keeps SECUREMODE as its settled secured position. The
+    internal state SECURING is the equivalent of the main lock's LOCKING
+    state. The model has no Secured to Locked transition.
+    """
+    if reported is LockStatus.SECURING:
+        # SECURING: if the main lock is already locked it stays locked.
+        # Any other state shows LOCKING on both channels.
+        if main in (LockStatus.LOCKED, LockStatus.SECUREMODE):
+            return main, LockStatus.LOCKING
+        return LockStatus.LOCKING, LockStatus.LOCKING
+    if reported is LockStatus.SECUREMODE:
+        return LockStatus.SECUREMODE, LockStatus.LOCKED
+    if reported is LockStatus.LOCKING:
+        # A plain lock(): the main lock is moving, the secure lock is not.
+        return reported, LockStatus.UNLOCKED
+    if reported in (LockStatus.UNLOCKING, LockStatus.UNLATCHING):
+        # The secure lock is moving only if it was secured, or was already
+        # unlocking.
+        if secure in (LockStatus.LOCKED, LockStatus.UNLOCKING):
+            return reported, LockStatus.UNLOCKING
+        return reported, LockStatus.UNLOCKED
+    if reported in (LockStatus.LOCKED, LockStatus.UNLOCKED, LockStatus.UNLATCHED):
+        # The lock may be locked, but it is not Secured.
+        return reported, LockStatus.UNLOCKED
+    # JAMMED, UNKNOWN, and the setup conditions are faults of the whole lock,
+    # so both channels carry them.
+    return reported, reported
+
+
 class PushLock:
     """A lock with push updates."""
 
@@ -453,6 +493,11 @@ class PushLock:
     def lock_status(self) -> LockStatus:
         """Return the current lock status."""
         return self._lock_state.lock if self._lock_state else LockStatus.UNKNOWN
+
+    @property
+    def secure_status(self) -> LockStatus:
+        """Return the current status of the secure lock."""
+        return self._lock_state.secure if self._lock_state else LockStatus.UNKNOWN
 
     @property
     def battery(self) -> BatteryState | None:
@@ -733,7 +778,7 @@ class PushLock:
     async def securemode(self) -> None:
         """Set the lock into securemode."""
         await self._run_lock_operation(
-            "force_securemode", LockStatus.LOCKING, LockStatus.SECUREMODE
+            "force_securemode", LockStatus.SECURING, LockStatus.SECUREMODE
         )
 
     async def lock(self) -> None:
@@ -839,22 +884,26 @@ class PushLock:
             self._update_any_state([outcome], arm_resync=False)
         self._force_lock_status_poll = True
         self._earliest_update_time = time.monotonic() + LOCK_STALE_STATE_DEBOUNCE_DELAY
-        # A settled status waits the keep-alive; an unsettled one polls at
+        # A settled pair waits the keep-alive; an unsettled one polls at
         # the stale-state debounce, the earliest a poll answers with the
-        # motor stopped.
-        if self.lock_status in POSITION_READINGS:
+        # motor stopped. The two motion values are the only transitional
+        # readings the projection publishes on the secure channel.
+        if self.lock_status in POSITION_READINGS and self.secure_status not in (
+            LockStatus.LOCKING,
+            LockStatus.UNLOCKING,
+        ):
             delay = KEEP_ALIVE_TIME
         else:
             delay = LOCK_STALE_STATE_DEBOUNCE_DELAY
         self._schedule_future_update_with_debounce(delay)
 
-    def _admit_lock_status(
-        self, incoming: LockStatus, current: LockStatus
-    ) -> LockStatus:
+    def _admit_lock_status(self, incoming: LockStatus) -> LockStatus | None:
         """Decide the displayed lock status for an incoming value.
 
         Every incoming lock status, polled or pushed, must pass through
-        here.
+        here. None refuses the value outright: the caller applies nothing
+        from it, so a refused status cannot reach _project_lock_status
+        either and the secure lock keeps its display.
         """
         if self._operation_window_open:
             # No received lock status is accepted between write-success and
@@ -870,7 +919,7 @@ class PushLock:
                 self.name,
                 incoming,
             )
-            return current
+            return None
         return incoming
 
     # The decorator retries only AuthError and RETRYABLE_EXCEPTIONS; the
@@ -1047,6 +1096,7 @@ class PushLock:
             self.auth,
             self.auto_lock,
             self.auto_lock_prev,
+            self.secure_status,
         )
 
     def _update_any_state(
@@ -1092,23 +1142,33 @@ class PushLock:
                 # equality check, so the admission filter is the single authority
                 # for the displayed value. A repeated identical reading is put
                 # through it too rather than short-circuited.
-                admitted = self._admit_lock_status(state, lock_state.lock)
+                admitted = self._admit_lock_status(state)
                 if admitted not in POSITION_READINGS:
                     # A display left on anything but a settled position must
                     # not suppress the follow-up poll, so LockStatus is
-                    # removed from _seen_this_session. A refused reading
-                    # leaves the operation's transitional standing, so it
-                    # reaches here too.
+                    # removed from _seen_this_session.
                     self._seen_this_session.discard(type(state))
-                if lock_state.lock != admitted:
-                    if admitted in SETUP_CONDITION_STATUSES:
+                if admitted is None:
+                    continue
+                # The projection runs on every admitted status, not only on
+                # one that moves the main lock: a securemode command given
+                # to an already-locked lock leaves lock at LOCKED, so gating
+                # the secure value on a changed lock would publish no
+                # securing transitional at all.
+                main, secure = _project_lock_status(
+                    admitted, lock_state.lock, lock_state.secure
+                )
+                if lock_state.lock != main:
+                    if main in SETUP_CONDITION_STATUSES:
                         _LOGGER.warning(
                             "%s: Lock reports %s, a setup condition that ends "
                             "at the lock by hand",
                             self.name,
-                            admitted,
+                            main,
                         )
-                    changes["lock"] = admitted
+                    changes["lock"] = main
+                if lock_state.secure != secure:
+                    changes["secure"] = secure
             elif isinstance(state, DoorStatus):
                 if lock_state.door != state:
                     changes["door"] = state

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -47,6 +47,7 @@ from .session import (
     NoAdvertisementError,
     OperationIncompleteError,
     ResponseError,
+    UnlatchError,
     YaleXSBLEError,
 )
 from .util import asyncio_timeout, is_disconnected_error, local_name_is_unique
@@ -796,6 +797,16 @@ class PushLock:
             "force_unlock", LockStatus.UNLOCKING, LockStatus.UNLOCKED
         )
 
+    async def unlatch(self) -> None:
+        """Unlatch (momentarily open) the lock.
+
+        The op-response arrives after the latch has returned, so the
+        completed state is UNLOCKED, not UNLATCHED.
+        """
+        await self._run_lock_operation(
+            "force_unlatch", LockStatus.UNLATCHING, LockStatus.UNLOCKED
+        )
+
     def _init_operation_state(self) -> None:
         """Initialize the per-operation fields.
 
@@ -813,9 +824,9 @@ class PushLock:
     ) -> None:
         """Run a lock operation; _finalize_operation runs on every exit.
 
-        The common body of lock(), unlock() and securemode(); it drives the
-        operation and leaves the display with the result, and failures raise
-        to the caller.
+        The common body of lock(), unlock(), securemode() and unlatch(); it
+        drives the operation and leaves the display with the result, and
+        failures raise to the caller.
         """
         self._cancel_future_update()
         self._operation_outcome = None
@@ -956,14 +967,10 @@ class PushLock:
             await getattr(lock, op_attr)(
                 write_success_callback=self._operation_write_success
             )
-        except OperationIncompleteError:
-            # Listed so it reaches the caller as itself: the arm below
-            # would convert it while a status stands recorded.
-            _LOGGER.debug(
-                "%s: %s did not complete; the result never arrived",
-                self.name,
-                op_attr,
-            )
+        except (OperationIncompleteError, UnlatchError):
+            # Listed so both types reach the caller as themselves: the arm
+            # below would convert them while a status stands recorded.
+            _LOGGER.debug("%s: %s ended without a result", self.name, op_attr)
             raise
         except Exception as ex:
             if (recorded := self._seen_intervention_status) is not None:

--- a/src/yalexs_ble/push.py
+++ b/src/yalexs_ble/push.py
@@ -36,6 +36,7 @@ from .const import (
     LockState,
     LockStateValue,
     LockStatus,
+    OperationError,
 )
 from .lock import Lock
 from .session import (
@@ -747,8 +748,20 @@ class PushLock:
                 ex,
             )
             raise
-        self._update_any_state([complete_state])
-        _LOGGER.debug("%s: Finished %s", self.name, complete_state)
+        # A failure op-response was already parsed into JAMMED and published
+        # before this write, so the commanded state must not replace it. The
+        # guard is only needed while this part of #369 stands alone: the
+        # parts that follow rework this path to raise on a reported failure,
+        # and they remove it.
+        if lock._last_op_error in (None, OperationError.COMM_SUCCESS):
+            self._update_any_state([complete_state])
+            _LOGGER.debug("%s: Finished %s", self.name, complete_state)
+        else:
+            _LOGGER.debug(
+                "%s: the lock reported %s failed; the reported state stays on display",
+                self.name,
+                op_attr,
+            )
         now = time.monotonic()
         self._last_lock_operation_complete_time = now
         self._complete_operation(now)

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from async_interrupt import interrupt
 from bleak import BleakClient
@@ -22,6 +23,22 @@ from .const import READ_CHARACTERISTIC, RESPONSE_FRAME_LEN, WRITE_CHARACTERISTIC
 _LOGGER = logging.getLogger(__name__)
 
 COOLDOWN_TIME = 0.25
+
+# How long execute() waits for the frame answering a command.
+RESPONSE_TIMEOUT = 10.0
+
+# How long stage 1 of a mechanical operation may take: the GATT write and
+# the acknowledgment that follows it. Sized off the link, not the
+# operation: above the ~6 s link supervision timeout, which counts from
+# the last reception, so a link already dead at the write presents as a
+# disconnect, not an expired stage.
+ACK_TIMEOUT = 8.0
+
+# Budget for a whole operation, command write to op-response. The motor
+# runs from the command write, and the acknowledgment is transport
+# acceptance, so a slow acknowledgment does not cut into motion time. An
+# operation with a longer motion passes its own budget.
+OPERATION_RESPONSE_TIMEOUT = 12.0
 
 
 class YaleXSBLEError(Exception):
@@ -46,6 +63,35 @@ class NoAdvertisementError(YaleXSBLEError):
 
 class BluetoothError(YaleXSBLEError):
     """Bluetooth error."""
+
+
+class OperationIncompleteError(YaleXSBLEError):
+    """The operation's result never arrived.
+
+    The command reached the lock, so the motor may have run, but the
+    op-response was lost. Deliberately not a retryable type: it ends the
+    retry attempts with the result unknown.
+    """
+
+
+@dataclass
+class OperationProgress:
+    """How far a mechanical operation got; error handling keys on the stage
+    reached.
+
+    write_attempted is set before the write call, because an errored write
+    can still have delivered the command. acknowledged and result are
+    recorded where the frames arrive, because a disconnect can cancel the
+    operation's wait before it resumes.
+
+    The caller owns the instance and execute_operation never resets it, so
+    recorded values outlive the call and a logically new operation needs a
+    fresh instance.
+    """
+
+    write_attempted: bool = False
+    acknowledged: bool = False
+    result: bytes | None = None
 
 
 class Session:
@@ -74,7 +120,17 @@ class Session:
         )
         self._notifications_started = False
         self._notify_future: asyncio.Future[bytes] | None = None
+        # When set, only a matching frame resolves the pending future; other
+        # valid frames still reach the state callback and the wait continues.
         self._notify_matcher: Callable[[bytes], bool] | None = None
+        # The acknowledgment wait of a staged operation. Armed together
+        # with the response future, before the write, so no frame falls
+        # between the two wait stages.
+        self._ack_future: asyncio.Future[bytes] | None = None
+        self._ack_matcher: Callable[[bytes], bool] | None = None
+        # Set for the whole staged wait, so _notify can tell a staged wait
+        # from a plain one after the acknowledgment stage has passed.
+        self._operation_progress: OperationProgress | None = None
         self._state_callback = state_callback
         self._disconnected_futures = disconnected_futures
         self._first_request = True
@@ -168,10 +224,7 @@ class Session:
     ) -> None:
         """Dispose of a frame that failed admission.
 
-        The frame is withheld from the state callback. A solicited wait still
-        receives the error, so _locked_write re-sends its command until its
-        attempts run out and it raises; an unsolicited frame has no waiter and
-        is dropped.
+        The frame is withheld from the state callback.
         """
         # The drop line carries the frame hex: these frames should not occur at
         # all, so a drop and its evidence are visible without turning debug on,
@@ -179,6 +232,14 @@ class Session:
         _LOGGER.log(
             level, "%s: dropping invalid frame %s: %s", self.name, frame.hex(), ex
         )
+        if self._operation_progress is not None:
+            # Failing a staged wait would re-send a mechanical command whose
+            # result is unknown, so the wait continues; the stage timeout is
+            # the backstop.
+            _LOGGER.debug(
+                "%s: Invalid frame during an operation wait, still waiting", self.name
+            )
+            return
         if (future := self._disarm_wait()) is not None and not future.done():
             future.set_exception(ex)
 
@@ -245,6 +306,21 @@ class Session:
         # why the call is guarded.
         if self._state_callback:
             self._state_callback(decrypted_data)
+        if (
+            (progress := self._operation_progress) is not None
+            and self._ack_future is not None
+            and self._ack_matcher is not None
+            and self._ack_matcher(decrypted_data)
+        ):
+            self._ack_future.set_result(decrypted_data)
+            self._ack_future = None
+            self._ack_matcher = None
+            # Recorded on arrival, not when the wait resumes: a disconnect
+            # can cancel the wait in the same event-loop turn, and an
+            # acknowledgment recorded nowhere reads as a delivery failure,
+            # whose retry re-sends a command the lock has taken.
+            progress.acknowledged = True
+            return
         if self._notify_future is None:
             return
         if self._notify_matcher is not None and not self._notify_matcher(
@@ -259,21 +335,18 @@ class Session:
                 self.name,
             )
             return
+        if progress is not None:
+            # Recorded on arrival for the same reason as the acknowledgment
+            # above.
+            progress.result = decrypted_data
         if (future := self._disarm_wait()) is not None and not future.done():
             future.set_result(decrypted_data)
 
-    async def _locked_write(
-        self,
-        command: bytearray,
-        command_name: str,
-        response_matcher: Callable[[bytes], bool] | None = None,
-    ) -> bytes:
+    def _encrypt_command(self, command: bytearray, command_name: str) -> None:
         # NOTE: The last two bytes are not encrypted
         # General idea seems to be that if the last byte
         # of the command indicates an offline key offset (is non-zero),
         # the command is "secure" and encrypted with the offline key
-        if not self.client.is_connected:
-            raise BleakError("disconnected")
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         plainText = command[0x00:0x10]
         cipherText = self.cipher_encrypt.update(plainText)
@@ -281,6 +354,16 @@ class Session:
         _LOGGER.debug(
             "%s: Encrypted command %s: %s", self.name, command_name, command.hex()
         )
+
+    async def _locked_write(
+        self,
+        command: bytearray,
+        command_name: str,
+        response_matcher: Callable[[bytes], bool] | None = None,
+    ) -> bytes:
+        if not self.client.is_connected:
+            raise BleakError("disconnected")
+        self._encrypt_command(command, command_name)
 
         future: asyncio.Future[bytes] | None = None
         try:
@@ -297,7 +380,7 @@ class Session:
                     command.hex(),
                 )
                 _LOGGER.debug("%s: Waiting for response", self.name)
-                async with util.asyncio_timeout(10):
+                async with util.asyncio_timeout(RESPONSE_TIMEOUT):
                     try:
                         await self.client.write_gatt_char(
                             self.write_characteristic, command, True
@@ -331,6 +414,120 @@ class Session:
                 ):
                     future.exception()
         _LOGGER.debug("%s: Got response: %s", self.name, result.hex())
+        return result
+
+    async def _locked_write_operation(
+        self,
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        """Write a mechanical command and run the staged wait.
+
+        Starting (or restarting) an operation initialises its timers: both
+        stage deadlines run from the attempt start. Stage 1 (ACK_TIMEOUT)
+        covers the GATT write and the typed acknowledgment; stage 2 (the
+        operation's response_timeout, also from attempt start) covers the
+        op-response, the physical end of movement. Only an op-response, or an
+        error, ends the wait.
+        """
+        if not self.client.is_connected:
+            raise BleakError("disconnected")
+        self._encrypt_command(command, command_name)
+
+        attempt_start = time.monotonic()
+        ack_future: asyncio.Future[bytes] = self.loop.create_future()
+        result_future: asyncio.Future[bytes] = self.loop.create_future()
+        # Armed before the write: re-arming between stages would race an
+        # op-response that follows the acknowledgment within milliseconds.
+        self._ack_future = ack_future
+        self._ack_matcher = ack_matcher
+        self._notify_future = result_future
+        self._notify_matcher = response_matcher
+        self._operation_progress = progress
+        try:
+            _LOGGER.debug(
+                "%s: Writing command to %s: %s",
+                self.name,
+                self.write_characteristic,
+                command.hex(),
+            )
+            # Set before the call: an errored write can still have delivered
+            # the command (the request leaves the radio, only the ATT
+            # response is lost).
+            progress.write_attempted = True
+            async with util.asyncio_timeout(ACK_TIMEOUT):
+                await self.client.write_gatt_char(
+                    self.write_characteristic, command, True
+                )
+            if write_success_callback is not None:
+                # Contained: an exception escaping here would be retried
+                # upstream and re-send a mechanical command. A raising hook
+                # is a bug in the caller.
+                try:
+                    write_success_callback()
+                except Exception:
+                    _LOGGER.exception(
+                        "%s: write success callback for %s raised, "
+                        "continuing the staged wait",
+                        self.name,
+                        command_name,
+                    )
+            _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
+            ack_remaining = ACK_TIMEOUT - (time.monotonic() - attempt_start)
+            done, _ = await asyncio.wait(
+                (ack_future, result_future),
+                timeout=max(ack_remaining, 0),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if result_future in done:
+                # The op-response supersedes the acknowledgment stage: it
+                # either beat the acknowledgment entirely, or both resolved in
+                # the same event-loop turn. Either way the op-response is the
+                # answer, and whether an acknowledgment also arrived was
+                # already recorded where it was received.
+                return result_future.result()
+            if ack_future not in done:
+                raise TimeoutError(
+                    f"{self.name}: No acknowledgment to {command_name} within "
+                    f"{ACK_TIMEOUT}s of the command being issued"
+                )
+            _LOGGER.debug("%s: Waiting for the op-response", self.name)
+            result_remaining = response_timeout - (time.monotonic() - attempt_start)
+            try:
+                async with util.asyncio_timeout(max(result_remaining, 0)):
+                    result = await result_future
+            except TimeoutError as err:
+                if (recorded := progress.result) is not None:
+                    # The op-response arrived in the same event-loop turn as
+                    # the timeout; report the recorded result, not the
+                    # timeout.
+                    _LOGGER.debug(
+                        "%s: op-response to %s arrived in the same turn as "
+                        "the stage-2 timeout; returning the recorded result",
+                        self.name,
+                        command_name,
+                    )
+                    return recorded
+                raise OperationIncompleteError(
+                    f"{self.name}: {command_name} was acknowledged but no "
+                    f"op-response arrived within {response_timeout}s of the "
+                    "command being issued"
+                ) from err
+        finally:
+            # Unconditional: the session lock serializes operations, so the
+            # record armed above is still this operation's own.
+            self._operation_progress = None
+            if self._ack_future is ack_future:
+                self._ack_future = None
+                self._ack_matcher = None
+            if self._notify_future is result_future:
+                self._notify_future = None
+                self._notify_matcher = None
         return result
 
     async def start_notify(self) -> None:
@@ -371,6 +568,20 @@ class Session:
         except BleakError as err:
             _LOGGER.debug("%s: Bleak error stopping notify: %s", self.name, err)
 
+    async def _wait_for_cooldown(self) -> None:
+        while (
+            self._enable_cooldown
+            and (cooldown_remain := time.monotonic() - self._last_callback_time)
+            < COOLDOWN_TIME
+        ):
+            _LOGGER.debug(
+                "%s: Waiting %s for lock to settle", self.name, cooldown_remain
+            )
+            # If we send commands to fast the lock may crash and stop
+            # advertising. This is a workaround to avoid that since
+            # it means a battery pull is required to recover.
+            await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
+
     async def execute(
         self,
         command: bytearray,
@@ -385,18 +596,7 @@ class Session:
         write times out). Without a matcher the first valid frame answers, as
         before.
         """
-        while (
-            self._enable_cooldown
-            and (cooldown_remain := time.monotonic() - self._last_callback_time)
-            < COOLDOWN_TIME
-        ):
-            _LOGGER.debug(
-                "%s: Waiting %s for lock to settle", self.name, cooldown_remain
-            )
-            # If we send commands to fast the lock may crash and stop
-            # advertising. This is a workaround to avoid that since
-            # it means a battery pull is required to recover.
-            await asyncio.sleep(COOLDOWN_TIME - cooldown_remain)
+        await self._wait_for_cooldown()
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
         self._write_checksum(command)
         disconnected_future = asyncio.get_running_loop().create_future()
@@ -413,6 +613,107 @@ class Session:
                     f"Authentication error: key or slot (key index) is incorrect: {err}"
                 ) from err
             if util.is_disconnected_error(err):
+                raise DisconnectedError(f"{self.name}: {err}") from err
+            raise
+        finally:
+            disconnected_futures.discard(disconnected_future)
+            self._first_request = False
+
+    def _outcome_after_disconnect(
+        self, progress: OperationProgress, command_name: str, err: Exception
+    ) -> bytes | None:
+        """Classify a lost link by how far the operation got.
+
+        Returns the op-response when the frame was recorded before the wait
+        was lost, raises OperationIncompleteError once the command was
+        acknowledged and the result is therefore unknown, and returns None
+        while nothing was acknowledged, which leaves the caller to raise the
+        retryable error the drop came in as.
+        """
+        if (result := progress.result) is not None:
+            # The op-response arrived in the same event-loop turn as the
+            # disconnect; report the recorded result.
+            _LOGGER.debug(
+                "%s: Disconnected in the same turn as the op-response to "
+                "%s; returning the recorded result",
+                self.name,
+                command_name,
+            )
+            return result
+        if progress.acknowledged:
+            raise OperationIncompleteError(
+                f"{self.name}: Disconnected while awaiting the op-response "
+                f"to {command_name}; the result is unknown"
+            ) from err
+        return None
+
+    async def execute_operation(
+        self,
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        """Execute a mechanical operation command with the staged wait.
+
+        Error policy by stage (the caller's retry decorator sees the types).
+        The acknowledgment carries no mechanical delay, so its absence
+        signals a delivery problem and predicts a missing op-response: write
+        and acknowledgment failures keep their retryable types (TimeoutError
+        / DisconnectedError / BleakError) and the retry re-sends the command
+        early rather than waiting out the op-response budget. Once the
+        operation is acknowledged, a timeout or disconnect raises the
+        non-retryable OperationIncompleteError, ending the attempt ladder: the
+        result is unknown and the caller decides.
+
+        response_timeout is the budget for the whole exchange, measured from
+        the moment the command is issued, and must exceed ACK_TIMEOUT: the
+        remainder left once the operation is acknowledged is the op-response
+        wait, so a value at or below ACK_TIMEOUT leaves that wait no time at
+        all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
+        sized here, and an operation with a longer motion passes its own.
+        """
+        await self._wait_for_cooldown()
+        assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
+        self._write_checksum(command)
+        disconnected_future = asyncio.get_running_loop().create_future()
+        disconnected_futures = self._disconnected_futures
+        disconnected_futures.add(disconnected_future)
+        try:
+            async with (
+                interrupt(
+                    disconnected_future,
+                    DisconnectedError,
+                    f"{self.name}: Disconnected",
+                ),
+                self._lock,
+            ):
+                return await self._locked_write_operation(
+                    command,
+                    command_name,
+                    ack_matcher,
+                    response_matcher,
+                    response_timeout,
+                    progress,
+                    write_success_callback,
+                )
+        except DisconnectedError as err:
+            result = self._outcome_after_disconnect(progress, command_name, err)
+            if result is not None:
+                return result
+            raise
+        except BleakError as err:
+            if self._first_request and util.is_key_error(err):
+                raise AuthError(
+                    f"Authentication error: key or slot (key index) is incorrect: {err}"
+                ) from err
+            if util.is_disconnected_error(err):
+                result = self._outcome_after_disconnect(progress, command_name, err)
+                if result is not None:
+                    return result
                 raise DisconnectedError(f"{self.name}: {err}") from err
             raise
         finally:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -687,7 +687,7 @@ class Session:
                 self.name,
                 command_name,
             )
-            return result
+            return self._completed(result, progress, command_name)
         if progress.acknowledged:
             raise OperationIncompleteError(
                 f"{self.name}: Disconnected while awaiting the op-response "

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from time import monotonic
 
 from async_interrupt import interrupt
 from bleak import BleakClient
@@ -244,7 +244,7 @@ class Session:
             future.set_exception(ex)
 
     def _notify(self, char: int, data: bytearray) -> None:
-        self._last_callback_time = time.monotonic()
+        self._last_callback_time = monotonic()
         _LOGGER.debug(
             "%s: Receiving response via notify: %s (waiting=%s)",
             self.name,
@@ -439,7 +439,7 @@ class Session:
             raise BleakError("disconnected")
         self._encrypt_command(command, command_name)
 
-        attempt_start = time.monotonic()
+        attempt_start = monotonic()
         ack_future: asyncio.Future[bytes] = self.loop.create_future()
         result_future: asyncio.Future[bytes] = self.loop.create_future()
         # Armed before the write: re-arming between stages would race an
@@ -478,7 +478,7 @@ class Session:
                         command_name,
                     )
             _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
-            ack_remaining = ACK_TIMEOUT - (time.monotonic() - attempt_start)
+            ack_remaining = ACK_TIMEOUT - (monotonic() - attempt_start)
             done, _ = await asyncio.wait(
                 (ack_future, result_future),
                 timeout=max(ack_remaining, 0),
@@ -502,7 +502,7 @@ class Session:
                     f"{ACK_TIMEOUT}s of the command being issued"
                 )
             _LOGGER.debug("%s: Waiting for the op-response", self.name)
-            result_remaining = response_timeout - (time.monotonic() - attempt_start)
+            result_remaining = response_timeout - (monotonic() - attempt_start)
             try:
                 async with util.asyncio_timeout(max(result_remaining, 0)):
                     result = await result_future
@@ -576,7 +576,7 @@ class Session:
     async def _wait_for_cooldown(self) -> None:
         while (
             self._enable_cooldown
-            and (cooldown_remain := time.monotonic() - self._last_callback_time)
+            and (cooldown_remain := monotonic() - self._last_callback_time)
             < COOLDOWN_TIME
         ):
             _LOGGER.debug(

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -34,16 +34,15 @@ RESPONSE_TIMEOUT = 10.0
 # disconnect, not an expired stage.
 ACK_TIMEOUT = 8.0
 
-# Budget for a whole operation, command write to op-response. The motor
-# runs from the command write, and the acknowledgment is transport
-# acceptance, so a slow acknowledgment does not cut into motion time. An
-# operation with a longer motion passes its own budget.
+# How long the whole operation, command write to op-response, may take. The
+# motor runs from the command write, and the acknowledgment is transport
+# acceptance, so it is expected before the motor stops.
 OPERATION_RESPONSE_TIMEOUT = 12.0
 
-# The operation budget for an unlatch: an unlatch is an unlock that also
-# fires the latch, so the latch's pull in, hold, and release stack on
-# the mechanical movement the plain budget covers.
-UNLATCH_OPERATION_RESPONSE_TIMEOUT = 20.0
+# How long the unlatch operation may take: an unlatch is an unlock that also
+# unlatches the door. A separate value to allow independent tuning of the
+# unlatch operation.
+UNLATCH_OPERATION_RESPONSE_TIMEOUT = 12.0
 
 
 class YaleXSBLEError(Exception):
@@ -696,28 +695,22 @@ class Session:
     ) -> bytes:
         """Execute a mechanical operation command with the staged wait.
 
-        With the acknowledgment stage in place, failures up to the
-        acknowledgment keep their retryable types, so the caller's retry
-        decorator re-sends early; the acknowledgment has no mechanical
-        delay, so its absence means delivery failed.
-        Later failures raise OperationIncompleteError, which ends the retry
-        attempts with the result unknown.
+        Failures up to the acknowledgment stay retryable, so the caller's
+        retry decorator re-sends early; the acknowledgment has no mechanical
+        delay, so its absence means delivery failed. Later failures raise
+        OperationIncompleteError, which ends the retry attempts with the
+        result unknown.
 
-        response_timeout is the budget for the whole exchange, measured from
-        the moment the command is issued. Size it above ACK_TIMEOUT: the
-        remainder left once the operation is acknowledged is the op-response
-        wait, so a budget at or below ACK_TIMEOUT leaves that wait no time
-        at all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
-        sized here, and an operation with a longer motion passes its own.
+        response_timeout is the maximum time allowed for the whole operation
+        including the mechanical operation time, measured from the moment the
+        command is issued. Sized above ACK_TIMEOUT.
 
         wait_for_ack=False skips the acknowledgment wait, for a caller
         whose failure handling must never re-send: a lost acknowledgment
         would otherwise end an operation whose result could still arrive.
-        It does not by itself stop a re-send: a post-write disconnect with
-        nothing acknowledged still raises its retryable type, so such a
-        caller converts on progress.write_attempted the way
-        Lock.force_unlatch does. The acknowledgment is still matched and
-        recorded when it lands; only the wait on it is dropped.
+        The acknowledgment is still matched and recorded when it lands;
+        only the wait on it is dropped. It does not by itself stop a re-send:
+        a post-write disconnect with nothing acknowledged is still retryable.
         """
         await self._wait_for_cooldown()
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -39,9 +39,10 @@ ACK_TIMEOUT = 8.0
 # acceptance, so it is expected before the motor stops.
 OPERATION_RESPONSE_TIMEOUT = 12.0
 
-# How long the unlatch operation may take: an unlatch is an unlock that also
-# unlatches the door. A separate value to allow independent tuning of the
-# unlatch operation.
+# How long the unlatch operation may take, command write to op-response.
+# Its end state is UNLATCHED, and the dwell after it is not part of the
+# operation. A separate constant to allow independent tuning of the unlatch
+# operation.
 UNLATCH_OPERATION_RESPONSE_TIMEOUT = 12.0
 
 
@@ -696,17 +697,21 @@ class Session:
         """Execute a mechanical operation command with the staged wait.
 
         Failures up to the acknowledgment stay retryable, so the caller's
-        retry decorator re-sends early; the acknowledgment has no mechanical
-        delay, so its absence means delivery failed. Later failures raise
-        OperationIncompleteError, which ends the retry attempts with the
-        result unknown.
+        retry decorator re-sends early. The acknowledgment has no mechanical
+        delay, so its absence means the command was not delivered or the
+        acknowledgment was dropped; an op-response that arrives anyway shows
+        it was dropped. Later failures raise OperationIncompleteError, which
+        ends the retry attempts with the result unknown.
 
-        response_timeout is the maximum time allowed for the whole operation
-        including the mechanical operation time, measured from the moment the
-        command is issued. Sized above ACK_TIMEOUT.
+        response_timeout bounds the whole operation, command write to
+        op-response, measured from the moment the command is issued. On
+        success the lock sends the op-response at the command's end state,
+        and what ends that state later is not part of the operation: the
+        dwell ends UNLATCHED after an unlatch, as auto-lock may end UNLOCKED
+        after an unlock. Sized above ACK_TIMEOUT.
 
         wait_for_ack=False skips the acknowledgment wait, for a caller
-        whose failure handling must never re-send: a lost acknowledgment
+        whose failure handling must never re-send: a dropped acknowledgment
         would otherwise end an operation whose result could still arrive.
         The acknowledgment is still matched and recorded when it lands;
         only the wait on it is dropped. It does not by itself stop a re-send:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -40,6 +40,11 @@ ACK_TIMEOUT = 8.0
 # operation with a longer motion passes its own budget.
 OPERATION_RESPONSE_TIMEOUT = 12.0
 
+# The operation budget for an unlatch: an unlatch is an unlock that also
+# fires the latch, so the latch's pull in, hold, and release stack on
+# the mechanical movement the plain budget covers.
+UNLATCH_OPERATION_RESPONSE_TIMEOUT = 20.0
+
 
 class YaleXSBLEError(Exception):
     """Base class for YaleXSBLE errors."""
@@ -71,6 +76,15 @@ class OperationIncompleteError(YaleXSBLEError):
     The command reached the lock, so the motor may have run, but the
     op-response was lost. Deliberately not a retryable type: it ends the
     retry attempts with the result unknown.
+    """
+
+
+class UnlatchError(YaleXSBLEError):
+    """An unlatch failed after its command write was attempted.
+
+    The command may have reached the lock, and a repeated unlatch opens the
+    door again, so nothing may re-send it. Deliberately not a retryable
+    type, so it passes through the retry decorator to the caller unchanged.
     """
 
 
@@ -425,15 +439,17 @@ class Session:
         response_timeout: float,
         progress: OperationProgress,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> bytes:
         """Write a mechanical command and run the staged wait.
 
-        Starting (or restarting) an operation initialises its timers: both
-        stage deadlines run from the attempt start. Stage 1 (ACK_TIMEOUT)
-        covers the GATT write and the typed acknowledgment; stage 2 (the
-        operation's response_timeout, also from attempt start) covers the
-        op-response, the physical end of movement. Only an op-response, or an
+        Both stage deadlines run from the attempt start: the acknowledgment
+        budget ACK_TIMEOUT covers the write and the acknowledgment, and
+        response_timeout covers the op-response. Only an op-response, or an
         error, ends the wait.
+
+        With wait_for_ack False the acknowledgment stage is skipped; the GATT
+        write keeps the same bound either way.
         """
         if not self.client.is_connected:
             raise BleakError("disconnected")
@@ -477,37 +493,40 @@ class Session:
                         self.name,
                         command_name,
                     )
-            _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
-            ack_remaining = ACK_TIMEOUT - (monotonic() - attempt_start)
-            done, _ = await asyncio.wait(
-                (ack_future, result_future),
-                timeout=max(ack_remaining, 0),
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if result_future in done:
-                # The op-response supersedes the acknowledgment stage: it
-                # either beat the acknowledgment entirely, or both resolved in
-                # the same event-loop turn. Either way the op-response is the
-                # answer, and whether an acknowledgment also arrived was
-                # already recorded where it was received. The matcher keys on
-                # the opcode alone, so the frame taken here can also be a
-                # previous same-opcode command's late op-response. That
-                # residual is accepted: requiring the acknowledgment first
-                # would instead drop a genuine op-response whose
-                # acknowledgment was lost.
-                if not progress.acknowledged:
-                    _LOGGER.info(
-                        "%s: %s completed on its op-response; no "
-                        "acknowledgment was received",
-                        self.name,
-                        command_name,
-                    )
-                return result_future.result()
-            if ack_future not in done:
-                raise TimeoutError(
-                    f"{self.name}: No acknowledgment to {command_name} within "
-                    f"{ACK_TIMEOUT}s of the command being issued"
+            if wait_for_ack:
+                _LOGGER.debug("%s: Waiting for acknowledgment", self.name)
+                ack_remaining = ACK_TIMEOUT - (monotonic() - attempt_start)
+                done, _ = await asyncio.wait(
+                    (ack_future, result_future),
+                    timeout=max(ack_remaining, 0),
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
+                if result_future in done:
+                    # The op-response supersedes the acknowledgment stage: it
+                    # either beat the acknowledgment entirely, or both
+                    # resolved in the same event-loop turn. Either way the
+                    # op-response is the answer, and whether an acknowledgment
+                    # also arrived was already recorded where it was received.
+                    # The matcher keys on the opcode alone, so the frame taken
+                    # here can also be a previous same-opcode command's late
+                    # op-response. That residual is accepted: requiring the
+                    # acknowledgment first would instead drop a genuine
+                    # op-response whose acknowledgment was lost.
+                    # The no-acknowledgment INFO belongs to this stage: with
+                    # the stage skipped the acknowledgment is a don't care.
+                    if not progress.acknowledged:
+                        _LOGGER.info(
+                            "%s: %s completed on its op-response; no "
+                            "acknowledgment was received",
+                            self.name,
+                            command_name,
+                        )
+                    return result_future.result()
+                if ack_future not in done:
+                    raise TimeoutError(
+                        f"{self.name}: No acknowledgment to {command_name} "
+                        f"within {ACK_TIMEOUT}s of the command being issued"
+                    )
             _LOGGER.debug("%s: Waiting for the op-response", self.name)
             result_remaining = response_timeout - (monotonic() - attempt_start)
             try:
@@ -525,10 +544,15 @@ class Session:
                         command_name,
                     )
                     return recorded
+                never_acknowledged = (
+                    ""
+                    if progress.acknowledged
+                    else "; the command was never acknowledged"
+                )
                 raise OperationIncompleteError(
-                    f"{self.name}: {command_name} was acknowledged but no "
-                    f"op-response arrived within {response_timeout}s of the "
-                    "command being issued"
+                    f"{self.name}: No op-response to {command_name} arrived "
+                    f"within {response_timeout}s of the command being issued"
+                    f"{never_acknowledged}"
                 ) from err
         finally:
             # Unconditional: the session lock serializes operations, so the
@@ -668,18 +692,16 @@ class Session:
         response_timeout: float,
         progress: OperationProgress,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> bytes:
         """Execute a mechanical operation command with the staged wait.
 
-        Error policy by stage (the caller's retry decorator sees the types).
-        The acknowledgment carries no mechanical delay, so its absence
-        signals a delivery problem and predicts a missing op-response: write
-        and acknowledgment failures keep their retryable types (TimeoutError
-        / DisconnectedError / BleakError) and the retry re-sends the command
-        early rather than waiting out the op-response budget. Once the
-        operation is acknowledged, a timeout or disconnect raises the
-        non-retryable OperationIncompleteError, ending the attempt ladder: the
-        result is unknown and the caller decides.
+        With the acknowledgment stage in place, failures up to the
+        acknowledgment keep their retryable types, so the caller's retry
+        decorator re-sends early; the acknowledgment has no mechanical
+        delay, so its absence means delivery failed.
+        Later failures raise OperationIncompleteError, which ends the retry
+        attempts with the result unknown.
 
         response_timeout is the budget for the whole exchange, measured from
         the moment the command is issued. Size it above ACK_TIMEOUT: the
@@ -687,6 +709,15 @@ class Session:
         wait, so a budget at or below ACK_TIMEOUT leaves that wait no time
         at all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
         sized here, and an operation with a longer motion passes its own.
+
+        wait_for_ack=False skips the acknowledgment wait, for a caller
+        whose failure handling must never re-send: a lost acknowledgment
+        would otherwise end an operation whose result could still arrive.
+        It does not by itself stop a re-send: a post-write disconnect with
+        nothing acknowledged still raises its retryable type, so such a
+        caller converts on progress.write_attempted the way
+        Lock.force_unlatch does. The acknowledgment is still matched and
+        recorded when it lands; only the wait on it is dropped.
         """
         await self._wait_for_cooldown()
         assert self.cipher_encrypt is not None, "Cipher not set"  # nosec
@@ -711,6 +742,7 @@ class Session:
                     response_timeout,
                     progress,
                     write_success_callback,
+                    wait_for_ack,
                 )
         except DisconnectedError as err:
             result = self._outcome_after_disconnect(progress, command_name, err)

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -512,16 +512,9 @@ class Session:
                     # op-response. That residual is accepted: requiring the
                     # acknowledgment first would instead drop a genuine
                     # op-response whose acknowledgment was lost.
-                    # The no-acknowledgment INFO belongs to this stage: with
-                    # the stage skipped the acknowledgment is a don't care.
-                    if not progress.acknowledged:
-                        _LOGGER.info(
-                            "%s: %s completed on its op-response; no "
-                            "acknowledgment was received",
-                            self.name,
-                            command_name,
-                        )
-                    return result_future.result()
+                    return self._completed(
+                        result_future.result(), progress, command_name
+                    )
                 if ack_future not in done:
                     raise TimeoutError(
                         f"{self.name}: No acknowledgment to {command_name} "
@@ -533,27 +526,26 @@ class Session:
                 async with util.asyncio_timeout(max(result_remaining, 0)):
                     result = await result_future
             except TimeoutError as err:
-                if (recorded := progress.result) is not None:
-                    # The op-response arrived in the same event-loop turn as
-                    # the timeout; report the recorded result, not the
-                    # timeout.
-                    _LOGGER.debug(
-                        "%s: op-response to %s arrived in the same turn as "
-                        "the stage-2 timeout; returning the recorded result",
-                        self.name,
-                        command_name,
+                if (recorded := progress.result) is None:
+                    never_acknowledged = (
+                        ""
+                        if progress.acknowledged
+                        else "; the command was never acknowledged"
                     )
-                    return recorded
-                never_acknowledged = (
-                    ""
-                    if progress.acknowledged
-                    else "; the command was never acknowledged"
+                    raise OperationIncompleteError(
+                        f"{self.name}: No op-response to {command_name} arrived "
+                        f"within {response_timeout}s of the command being issued"
+                        f"{never_acknowledged}"
+                    ) from err
+                # The op-response arrived in the same event-loop turn as the
+                # timeout; report the recorded result, not the timeout.
+                _LOGGER.debug(
+                    "%s: op-response to %s arrived in the same turn as "
+                    "the stage-2 timeout; returning the recorded result",
+                    self.name,
+                    command_name,
                 )
-                raise OperationIncompleteError(
-                    f"{self.name}: No op-response to {command_name} arrived "
-                    f"within {response_timeout}s of the command being issued"
-                    f"{never_acknowledged}"
-                ) from err
+                result = recorded
         finally:
             # Unconditional: the session lock serializes operations, so the
             # record armed above is still this operation's own.
@@ -564,6 +556,26 @@ class Session:
             if self._notify_future is result_future:
                 self._notify_future = None
                 self._notify_matcher = None
+        return self._completed(result, progress, command_name)
+
+    def _completed(
+        self, result: bytes, progress: OperationProgress, command_name: str
+    ) -> bytes:
+        """Return the op-response, logging a completion the lock never acknowledged.
+
+        The op-response is matched on the opcode alone, so a completion with
+        no acknowledgment recorded means either the acknowledgment was
+        dropped or a previous same-opcode command's late op-response
+        completed this wait. This line is the only trace of either in a
+        field log, so every completion path returns through here, the
+        unlatch's included, which skips the acknowledgment wait.
+        """
+        if not progress.acknowledged:
+            _LOGGER.info(
+                "%s: %s completed on its op-response; no acknowledgment was received",
+                self.name,
+                command_name,
+            )
         return result
 
     async def start_notify(self) -> None:

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -675,10 +675,10 @@ class Session:
         result is unknown and the caller decides.
 
         response_timeout is the budget for the whole exchange, measured from
-        the moment the command is issued, and must exceed ACK_TIMEOUT: the
+        the moment the command is issued. Size it above ACK_TIMEOUT: the
         remainder left once the operation is acknowledged is the op-response
-        wait, so a value at or below ACK_TIMEOUT leaves that wait no time at
-        all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
+        wait, so a budget at or below ACK_TIMEOUT leaves that wait no time
+        at all. OPERATION_RESPONSE_TIMEOUT is that budget for the operations
         sized here, and an operation with a longer motion passes its own.
         """
         await self._wait_for_cooldown()

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -495,6 +495,13 @@ class Session:
                 # residual is accepted: requiring the acknowledgment first
                 # would instead drop a genuine op-response whose
                 # acknowledgment was lost.
+                if not progress.acknowledged:
+                    _LOGGER.info(
+                        "%s: %s completed on its op-response; no "
+                        "acknowledgment was received",
+                        self.name,
+                        command_name,
+                    )
                 return result_future.result()
             if ack_future not in done:
                 raise TimeoutError(

--- a/src/yalexs_ble/session.py
+++ b/src/yalexs_ble/session.py
@@ -489,7 +489,12 @@ class Session:
                 # either beat the acknowledgment entirely, or both resolved in
                 # the same event-loop turn. Either way the op-response is the
                 # answer, and whether an acknowledgment also arrived was
-                # already recorded where it was received.
+                # already recorded where it was received. The matcher keys on
+                # the opcode alone, so the frame taken here can also be a
+                # previous same-opcode command's late op-response. That
+                # residual is accepted: requiring the acknowledgment first
+                # would instead drop a genuine op-response whose
+                # acknowledgment was lost.
                 return result_future.result()
             if ack_future not in done:
                 raise TimeoutError(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -273,6 +273,24 @@ def test_parse_lock_status_decodes_the_unlatch_states(
     assert ("Unrecognized lock_status_str" in caplog.text) is diagnostic_logged
 
 
+def test_a_frame_value_matching_securing_is_unrecognized(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A frame carrying SECURING's value never decodes to the member.
+
+    SECURING is library-synthesized and excluded from VALUE_TO_LOCK_STATUS,
+    so a frame carrying its byte cannot forge the securing stamp: it takes
+    the unrecognized-code path like any other value the lock does not
+    report.
+    """
+    lock = _make_lock()
+
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        assert lock._parse_lock_status(LockStatus.SECURING.value) is LockStatus.UNKNOWN
+
+    assert "Unrecognized lock_status_str" in caplog.text
+
+
 def test_parse_success_op_response_with_0200_trailer_is_no_update(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from bleak.exc import BleakError
 from bleak_retry_connector import BLEDevice
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from yalexs_ble.const import (
     FIRMWARE_REVISION_CHARACTERISTIC,
@@ -23,6 +24,7 @@ from yalexs_ble.const import (
     LockOperationSource,
     LockStateValue,
     LockStatus,
+    OperationError,
     SettingType,
     StatusType,
 )
@@ -317,15 +319,6 @@ def test_parse_bogus_frame_is_none_and_logs_unknown(
         lock._internal_state_callback(frame)
 
     assert "Unknown state" in caplog.text
-
-
-def test_parse_ack_still_reports_state() -> None:
-    """The AA transport-ack path is unchanged by the op-response decode."""
-    lock = _make_lock()
-
-    result = lock._parse_state(bytes.fromhex("aa0b00490000000000000000000000000200"))
-    assert result is not None
-    assert list(result) == [LockStatus.LOCKED]
 
 
 def test_internal_state_callback_emits_recognized_state() -> None:
@@ -1005,3 +998,268 @@ def test_operation_response_matcher_matches_only_its_opcode() -> None:
     assert not matches(bytes.fromhex("aa0a00000000000000000000000000000200"))
     # Truncated: byte[15] (the result) is not present.
     assert not matches(bytes.fromhex("bb0a0000000000000000"))
+
+
+async def _spin_until(predicate: Callable[[], bool]) -> None:
+    """Yield to the event loop until predicate() holds (bounded)."""
+    for _ in range(1000):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition was never reached")
+
+
+def _make_connected_lock_with_session(
+    state_callback: Callable[[Iterable[LockStateValue]], None] = lambda _: None,
+) -> Lock:
+    """Build a connected Lock backed by a real Session over a mock BLE client.
+
+    Mirrors tests/test_session.py: only cipher_encrypt is set, so notify frames
+    pass through Session.decrypt unchanged and can be fed verbatim. The
+    encryptor is a real one and the session encrypts the command buffer in
+    place, so an operation driven through here completes only if its matchers
+    read their expected bytes out of that buffer before the encryption.
+    """
+    lock = _make_lock(state_callback)
+    client = MagicMock()
+    client.is_connected = True
+    client.write_gatt_char = AsyncMock()
+    lock.client = client
+    lock.secure_session = MagicMock()
+    session = Session(
+        client, "mylock", asyncio.Lock(), set(), lock._internal_state_callback
+    )
+    session.cipher_encrypt = Cipher(
+        algorithms.AES(bytes(16)),
+        modes.CBC(bytes(16)),
+    ).encryptor()
+    lock.session = session
+    return lock
+
+
+# --------------------------------------------------------------------------- #
+# Mechanical operations through the staged session wait
+# --------------------------------------------------------------------------- #
+
+
+def _op_response_frame(opcode: int, result: int = OperationError.COMM_SUCCESS) -> bytes:
+    """A 0xBB op-response carrying the operation result in byte[15].
+
+    Built to the layout the matchers key on.
+    """
+    frame = bytearray(0x12)
+    frame[0x00] = 0xBB
+    frame[0x01] = opcode
+    frame[0x0F] = result
+    return _with_checksum(frame.hex())
+
+
+async def _drive_operation(lock: Lock, op_attr: str, opcode: int, ack: bytes) -> None:
+    """Run a force_* method, feeding its ack then op-response through notify.
+
+    The acknowledgement has to be matched before the op-response is fed. A
+    command carrying the wrong operation byte, or a matcher that never
+    matches, would otherwise still complete on the op-response alone and the
+    operation would look correct.
+    """
+    session = lock.session
+    assert session is not None
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._ack_future is not None)
+        session._notify(0, bytearray(ack))
+        assert session._ack_future is None, "the acknowledgement was not matched"
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(_op_response_frame(opcode)))
+
+    feeder = asyncio.create_task(feed())
+    await getattr(lock, op_attr)()
+    await feeder
+
+
+def test_parse_operation_ack_reports_no_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Operation acks (0xAA LOCK/UNLOCK) are recognized but carry no state.
+
+    They carry the command's opcode with no result, so a securemode request
+    (acknowledged on the 0x0B Lock opcode) used to display a false LOCKED.
+    State now comes from the op-response; the ack is recognized (empty
+    iterable), emits nothing, and must not surface as an unknown frame.
+    """
+    states: list[list[LockStateValue]] = []
+    lock = _make_lock(lambda s: states.append(list(s)))
+
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        for frame_hex in (
+            "aa0b00490000000000000000000000000200",
+            "aa0a004a0000000000000000000000000200",
+        ):
+            frame = bytes.fromhex(frame_hex)
+            result = lock._parse_state(frame)
+            assert result is not None
+            assert list(result) == []
+            lock._internal_state_callback(frame)
+
+    assert states == []  # the state callback was never invoked
+    assert "Unknown state" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("op_attr", "opcode", "ack_hex"),
+    [
+        ("force_lock", Commands.LOCK, "aa0b00490000000000000000000000000200"),
+        ("force_unlock", Commands.UNLOCK, "aa0a004a0000000000000000000000000200"),
+        (
+            "force_securemode",
+            Commands.LOCK,
+            "aa0b00450400000000000000000000000200",
+        ),
+    ],
+    ids=["lock", "unlock", "securemode"],
+)
+async def test_force_operations_complete_on_ack_then_op_response(
+    op_attr: str, opcode: int, ack_hex: str
+) -> None:
+    """Each force_* completes only on its own ack, then its 0xBB op-response.
+
+    Drives _execute_operation_command end to end through the real staged
+    session wait, on field-captured acknowledgements. Their byte[4] is the
+    operation byte the command must have carried, so the acknowledgement only
+    matches if the right command went out.
+    """
+    lock = _make_connected_lock_with_session()
+
+    await _drive_operation(lock, op_attr, opcode, bytes.fromhex(ack_hex))
+
+
+@pytest.mark.asyncio
+async def test_an_op_response_for_another_opcode_does_not_complete_the_wait() -> None:
+    """The staged wait completes only on the op-response matching its opcode.
+
+    While a force_lock is in flight, an unsolicited op-response carrying the
+    Unlock opcode lands first, the failure report the lock sends for an
+    operation nothing of ours started. It must leave the wait armed; only the
+    op-response carrying the Lock opcode completes the operation, so the result
+    is read from the right frame.
+    """
+    lock = _make_connected_lock_with_session()
+    session = lock.session
+    assert session is not None
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._ack_future is not None)
+        session._notify(
+            0, bytearray(bytes.fromhex("aa0b00490000000000000000000000000200"))
+        )
+        assert session._ack_future is None, "the acknowledgment was not matched"
+        await asyncio.sleep(0)
+        session._notify(
+            0,
+            bytearray(
+                _op_response_frame(Commands.UNLOCK, OperationError.MECH_POSITION)
+            ),
+        )
+        assert session._notify_future is not None, (
+            "an op-response for another opcode completed the wait"
+        )
+        session._notify(0, bytearray(_op_response_frame(Commands.LOCK)))
+
+    feeder = asyncio.create_task(feed())
+    await lock.force_lock()
+    await feeder
+
+
+@pytest.mark.asyncio
+async def test_a_door_push_does_not_answer_the_acknowledgment_stage() -> None:
+    """A door push landing mid-operation leaves the acknowledgment stage armed.
+
+    A door push can land between the command and the op-response, so it is a
+    frame the acknowledgment matcher has to tell from an acknowledgment. It
+    reaches the state callback like any other frame, which is what shows the
+    stage stayed armed on an admitted frame rather than on a rejected one.
+    Crediting a delivery that never happened costs the caller its retry: a
+    link lost afterwards reports the result unknown instead of retryable.
+    """
+    states: list[list[LockStateValue]] = []
+    lock = _make_connected_lock_with_session(lambda s: states.append(list(s)))
+    session = lock.session
+    assert session is not None
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._ack_future is not None)
+        session._notify(0, bytearray(DOOR_FRAME))
+        still_armed = session._ack_future is not None
+        assert still_armed, "a door push was taken for the acknowledgment"
+        await asyncio.sleep(0)
+        session._notify(
+            0, bytearray(bytes.fromhex("aa0b00490000000000000000000000000200"))
+        )
+        assert session._ack_future is None, "the acknowledgment was not matched"
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(_op_response_frame(Commands.LOCK)))
+
+    feeder = asyncio.create_task(feed())
+    await lock.force_lock()
+    await feeder
+
+    assert states == [[DoorStatus.CLOSED]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("wrapper", "force_attr"),
+    [
+        ("securemode", "force_securemode"),
+        ("lock", "force_lock"),
+        ("unlock", "force_unlock"),
+    ],
+    ids=["securemode", "lock", "unlock"],
+)
+async def test_convenience_wrappers_run_the_operation_outside_the_target_state(
+    wrapper: str, force_attr: str
+) -> None:
+    """A wrapper finding the lock outside its target state runs the operation.
+
+    The wrappers are the exported convenience surface, and delegation is
+    their whole contract.
+    """
+    lock = _make_lock()
+
+    with (
+        patch.object(lock, "lock_status", AsyncMock(return_value=LockStatus.UNKNOWN)),
+        patch.object(lock, force_attr, AsyncMock()) as mock_force,
+    ):
+        await getattr(lock, wrapper)()
+
+    mock_force.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("wrapper", "target_status", "force_attr"),
+    [
+        ("securemode", LockStatus.SECUREMODE, "force_securemode"),
+        ("lock", LockStatus.LOCKED, "force_lock"),
+        ("unlock", LockStatus.UNLOCKED, "force_unlock"),
+    ],
+    ids=["securemode", "lock", "unlock"],
+)
+async def test_convenience_wrappers_skip_the_operation_in_the_target_state(
+    wrapper: str, target_status: LockStatus, force_attr: str
+) -> None:
+    """A wrapper finding the lock already in its target state issues nothing.
+
+    No operation is issued, so nothing could have failed and the caller's
+    goal state holds.
+    """
+    lock = _make_lock()
+
+    with (
+        patch.object(lock, "lock_status", AsyncMock(return_value=target_status)),
+        patch.object(lock, force_attr, AsyncMock()) as mock_force,
+    ):
+        await getattr(lock, wrapper)()
+
+    mock_force.assert_not_awaited()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1471,7 +1471,7 @@ async def test_force_unlatch_passes_its_own_op_response_budget(
 
 
 @pytest.mark.asyncio
-async def test_every_operation_names_the_budget_its_motion_needs() -> None:
+async def test_every_operation_passes_a_budget_explicitly() -> None:
     """Each operation passes a budget explicitly; none inherits one.
 
     _execute_operation_command takes the budget as a required argument, so an

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -29,6 +29,8 @@ from yalexs_ble.const import (
 from yalexs_ble.lock import (
     AA_BATTERY_VOLTAGE_TO_PERCENTAGE,
     Lock,
+    _ack_matcher,
+    _operation_response_matcher,
     _poll_response_matcher,
     _settings_response_matcher,
     convert_voltage_to_percentage,
@@ -975,3 +977,31 @@ async def test_the_auto_lock_read_completes_on_its_acknowledgment() -> None:
     session.client.write_gatt_char = AsyncMock(side_effect=deliver)
 
     await lock.auto_lock_status()
+
+
+def test_ack_matcher_matches_only_the_written_operation() -> None:
+    """The ack matcher keys on 0xAA + the written opcode + operation byte."""
+    matches = _ack_matcher(0x0B, 0x04)
+
+    # Correct ack: 0xAA, opcode 0x0B, operation byte 0x04.
+    assert matches(bytes.fromhex("aa0b00450400000000000000000000000200"))
+    # Same opcode but operation byte 0x00, a plain-lock ack, not securemode.
+    assert not matches(bytes.fromhex("aa0b00490000000000000000000000000200"))
+    # Wrong opcode (0x0A).
+    assert not matches(bytes.fromhex("aa0a004a0000000000000000000000000200"))
+    # An op-response (0xBB), not an acknowledgment.
+    assert not matches(bytes.fromhex("bb0b00450400000000000000000000000200"))
+
+
+def test_operation_response_matcher_matches_only_its_opcode() -> None:
+    """The op-response matcher keys on 0xBB + the sent opcode, full length."""
+    matches = _operation_response_matcher(0x0A)
+
+    # An 18-byte 0xBB 0x0A op-response.
+    assert matches(bytes.fromhex("bb0a00000000000000000000000000000200"))
+    # Wrong opcode (0x0B).
+    assert not matches(bytes.fromhex("bb0b00000000000000000000000000000200"))
+    # An acknowledgment (0xAA), not an op-response.
+    assert not matches(bytes.fromhex("aa0a00000000000000000000000000000200"))
+    # Truncated: byte[15] (the result) is not present.
+    assert not matches(bytes.fromhex("bb0a0000000000000000"))

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -217,6 +217,62 @@ def test_parse_getstatus_staticposition() -> None:
     assert list(result) == [LockStatus.JAMMED]
 
 
+@pytest.mark.parametrize(
+    ("frame_hex", "expected"),
+    [
+        # Synthetic frames built to the GETSTATUS layout; not captured
+        # device frames.
+        ("bb0200380200000009000000000000000000", LockStatus.UNLATCHING),
+        ("bb020037020000000a000000000000000000", LockStatus.UNLATCHED),
+    ],
+    ids=["unlatching", "unlatched"],
+)
+def test_parse_getstatus_unlatch_states(frame_hex: str, expected: LockStatus) -> None:
+    """A GETSTATUS position of 0x09 or 0x0A decodes to the unlatch states.
+
+    Both decoded as UNKNOWN while the two members were commented out of
+    LockStatus, since VALUE_TO_LOCK_STATUS is derived from that enum.
+    """
+    lock = _make_lock()
+
+    result = lock._parse_state(bytes.fromhex(frame_hex))
+
+    assert result is not None
+    assert list(result) == [expected]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "diagnostic_logged"),
+    [
+        (0x09, LockStatus.UNLATCHING, False),
+        (0x0A, LockStatus.UNLATCHED, False),
+        (0x08, LockStatus.UNKNOWN, True),
+    ],
+    ids=["unlatching", "unlatched", "still_unmapped"],
+)
+def test_parse_lock_status_decodes_the_unlatch_states(
+    value: int,
+    expected: LockStatus,
+    diagnostic_logged: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared decode takes the two values, and stops logging them.
+
+    _parse_lock_status has four call sites: the GETSTATUS LOCK_ONLY branch,
+    the DOOR_AND_LOCK branch, the activity LOCK record's status byte, and the
+    low nibble of the activity PIN record's status byte, so the change lands at
+    all four. Both values logged an "Unrecognized lock_status_str code" line at
+    every one of them while the members were commented out of LockStatus, and
+    0x08, still unmapped, still logs it, which is where the change stops.
+    """
+    lock = _make_lock()
+
+    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
+        assert lock._parse_lock_status(value) is expected
+
+    assert ("Unrecognized lock_status_str" in caplog.text) is diagnostic_logged
+
+
 def test_parse_success_op_response_with_0200_trailer_is_no_update(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1054,27 +1110,39 @@ def _op_response_frame(opcode: int, result: int = OperationError.COMM_SUCCESS) -
     return _with_checksum(frame.hex())
 
 
-async def _drive_operation(lock: Lock, op_attr: str, opcode: int, ack: bytes) -> None:
+async def _drive_operation(
+    lock: Lock, op_attr: str, opcode: int, ack: bytes
+) -> list[str]:
     """Run a force_* method, feeding its ack then op-response through notify.
 
-    The acknowledgement has to be matched before the op-response is fed. A
+    The acknowledgment has to be matched before the op-response is fed. A
     command carrying the wrong operation byte, or a matcher that never
     matches, would otherwise still complete on the op-response alone and the
     operation would look correct.
+
+    The operation is given a write-success callback of this helper's own, and
+    the returned list records that callback and the two fed frames in the
+    order they landed.
     """
     session = lock.session
     assert session is not None
+    events: list[str] = []
 
     async def feed() -> None:
         await _spin_until(lambda: session._ack_future is not None)
+        events.append("ack")
         session._notify(0, bytearray(ack))
-        assert session._ack_future is None, "the acknowledgement was not matched"
+        assert session._ack_future is None, "the acknowledgment was not matched"
         await asyncio.sleep(0)
+        events.append("op_response")
         session._notify(0, bytearray(_op_response_frame(opcode)))
 
     feeder = asyncio.create_task(feed())
-    await getattr(lock, op_attr)()
+    await getattr(lock, op_attr)(
+        write_success_callback=lambda: events.append("write_success")
+    )
     await feeder
+    return events
 
 
 def test_parse_operation_ack_reports_no_state(
@@ -1122,16 +1190,21 @@ def test_parse_operation_ack_reports_no_state(
 async def test_force_operations_complete_on_ack_then_op_response(
     op_attr: str, opcode: int, ack_hex: str
 ) -> None:
-    """Each force_* completes only on its own ack, then its 0xBB op-response.
+    """Each force_* completes only on its own ack, then its 0xBB op-response,
+    and hands the caller's write-success callback down to the session.
 
     Drives _execute_operation_command end to end through the real staged
-    session wait, on field-captured acknowledgements. Their byte[4] is the
-    operation byte the command must have carried, so the acknowledgement only
-    matches if the right command went out.
+    session wait, on field-captured acknowledgments. Their byte[4] is the
+    operation byte the command must have carried, so the acknowledgment only
+    matches if the right command went out. The callback is the caller's
+    signal that the command reached the lock, so it has to run once per
+    operation and before any answering frame arrives.
     """
     lock = _make_connected_lock_with_session()
 
-    await _drive_operation(lock, op_attr, opcode, bytes.fromhex(ack_hex))
+    events = await _drive_operation(lock, op_attr, opcode, bytes.fromhex(ack_hex))
+
+    assert events == ["write_success", "ack", "op_response"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -8,6 +8,7 @@ from bleak.exc import BleakError
 from bleak_retry_connector import BLEDevice
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+import yalexs_ble
 from yalexs_ble.const import (
     FIRMWARE_REVISION_CHARACTERISTIC,
     MODEL_NUMBER_CHARACTERISTIC,
@@ -30,6 +31,7 @@ from yalexs_ble.const import (
 )
 from yalexs_ble.lock import (
     AA_BATTERY_VOLTAGE_TO_PERCENTAGE,
+    UNLATCH_OPERATION_BYTE,
     Lock,
     _ack_matcher,
     _operation_response_matcher,
@@ -37,7 +39,15 @@ from yalexs_ble.lock import (
     _settings_response_matcher,
     convert_voltage_to_percentage,
 )
-from yalexs_ble.session import Session
+from yalexs_ble.session import (
+    OPERATION_RESPONSE_TIMEOUT,
+    UNLATCH_OPERATION_RESPONSE_TIMEOUT,
+    DisconnectedError,
+    OperationIncompleteError,
+    OperationProgress,
+    Session,
+    UnlatchError,
+)
 from yalexs_ble.util import _simple_checksum
 
 
@@ -1112,6 +1122,23 @@ def _make_connected_lock_with_session(
 # --------------------------------------------------------------------------- #
 
 
+# Operation acknowledgments taken from the wire; the unlatch frame is built
+# by _ack_frame below.
+_LOCK_ACK_HEX = "aa0b00490000000000000000000000000200"
+_UNLOCK_ACK_HEX = "aa0a004a0000000000000000000000000200"
+_SECUREMODE_ACK_HEX = "aa0b00450400000000000000000000000200"
+
+
+def _ack_frame(opcode: int, operation_byte: int) -> bytes:
+    """A 0xAA acknowledgment carrying an operation's opcode and operation byte."""
+    frame = bytearray(0x12)
+    frame[0x00] = 0xAA
+    frame[0x01] = opcode
+    frame[0x04] = operation_byte
+    frame[0x10] = 0x02
+    return _with_checksum(frame.hex())
+
+
 def _op_response_frame(opcode: int, result: int = OperationError.COMM_SUCCESS) -> bytes:
     """A 0xBB op-response carrying the operation result in byte[15].
 
@@ -1189,34 +1216,37 @@ def test_parse_operation_ack_reports_no_state(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("op_attr", "opcode", "ack_hex"),
+    ("op_attr", "opcode", "ack"),
     [
-        ("force_lock", Commands.LOCK, "aa0b00490000000000000000000000000200"),
-        ("force_unlock", Commands.UNLOCK, "aa0a004a0000000000000000000000000200"),
+        ("force_lock", Commands.LOCK, bytes.fromhex(_LOCK_ACK_HEX)),
+        ("force_unlock", Commands.UNLOCK, bytes.fromhex(_UNLOCK_ACK_HEX)),
+        ("force_securemode", Commands.LOCK, bytes.fromhex(_SECUREMODE_ACK_HEX)),
         (
-            "force_securemode",
-            Commands.LOCK,
-            "aa0b00450400000000000000000000000200",
+            "force_unlatch",
+            Commands.UNLOCK,
+            _ack_frame(Commands.UNLOCK, UNLATCH_OPERATION_BYTE),
         ),
     ],
-    ids=["lock", "unlock", "securemode"],
+    ids=["lock", "unlock", "securemode", "unlatch"],
 )
 async def test_force_operations_complete_on_ack_then_op_response(
-    op_attr: str, opcode: int, ack_hex: str
+    op_attr: str, opcode: int, ack: bytes
 ) -> None:
-    """Each force_* completes only on its own ack, then its 0xBB op-response,
-    and hands the caller's write-success callback down to the session.
+    """Each force_* sends a command whose acknowledgment carries its own
+    opcode and operation byte, completes on its 0xBB op-response, and hands
+    the caller's write-success callback down to the session.
 
     Drives _execute_operation_command end to end through the real staged
-    session wait, on field-captured acknowledgments. Their byte[4] is the
-    operation byte the command must have carried, so the acknowledgment only
-    matches if the right command went out. The callback is the caller's
-    signal that the command reached the lock, so it has to run once per
-    operation and before any answering frame arrives.
+    session wait. The lock, unlock and securemode acknowledgments are field
+    captures; the unlatch one has no capture and is built to the same layout.
+    byte[4] is the operation byte the command must have carried, so the
+    acknowledgment only matches if the right command went out. The callback
+    is the caller's signal that the command reached the lock, so it has to
+    run once per operation and before any answering frame arrives.
     """
     lock = _make_connected_lock_with_session()
 
-    events = await _drive_operation(lock, op_attr, opcode, bytes.fromhex(ack_hex))
+    events = await _drive_operation(lock, op_attr, opcode, ack)
 
     assert events == ["write_success", "ack", "op_response"]
 
@@ -1350,3 +1380,388 @@ async def test_convenience_wrappers_skip_the_operation_in_the_target_state(
         await getattr(lock, wrapper)()
 
     mock_force.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_unlatch_wrapper_runs_force_unlatch() -> None:
+    """Lock.unlatch() always fires force_unlatch and completes on its op-response.
+
+    Unlatch is momentary, so there is no steady "unlatched" state to
+    short-circuit on the way lock()/unlock() do; the wrapper returns once the
+    op-response arrives.
+    """
+    lock = _make_connected_lock_with_session()
+    session = lock.session
+    assert session is not None
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._ack_future is not None)
+        session._notify(
+            0, bytearray(_ack_frame(Commands.UNLOCK, UNLATCH_OPERATION_BYTE))
+        )
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(_op_response_frame(Commands.UNLOCK)))
+
+    feeder = asyncio.create_task(feed())
+    with patch.object(
+        session, "build_operation_command", wraps=session.build_operation_command
+    ) as built:
+        await lock.unlatch()
+    await feeder
+
+    # force_unlock builds a plain Unlock through build_command, so a wrapper
+    # wired to it would never reach this call at all. The wrapper returns
+    # nothing, as its three siblings do.
+    built.assert_called_once_with(Commands.UNLOCK, UNLATCH_OPERATION_BYTE)
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_grants_the_extended_op_response_budget() -> None:
+    """Unlatch gets the longer op-response budget because it is a longer motion.
+
+    force_unlatch passes UNLATCH_OPERATION_RESPONSE_TIMEOUT, and encodes
+    unlatch as the Unlock opcode with the unlatch operation byte (there is
+    no dedicated unlatch opcode).
+
+    The opcode and operation byte are asserted against the wire values, not
+    against the constants that produced them: #351 sent operation byte 0x01.
+    The budget is asserted to exceed the plain one, the property the
+    extension exists for.
+    """
+    lock = _make_lock()
+    session = MagicMock()
+
+    def _build(opcode: int, cmd_byte: int) -> bytearray:
+        cmd = bytearray(0x12)
+        cmd[0x01] = opcode
+        cmd[0x04] = cmd_byte
+        return cmd
+
+    session.build_operation_command.side_effect = _build
+    lock.session = session
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    captured_command: bytearray | None = None
+    captured_timeout: float | None = None
+
+    async def _capture(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        nonlocal captured_command, captured_timeout
+        captured_command = command
+        captured_timeout = response_timeout
+
+    lock._execute_operation_command = _capture  # type: ignore[method-assign]
+
+    await lock.force_unlatch()
+    assert captured_timeout == UNLATCH_OPERATION_RESPONSE_TIMEOUT
+    assert UNLATCH_OPERATION_RESPONSE_TIMEOUT > OPERATION_RESPONSE_TIMEOUT
+    assert captured_command is not None
+    assert captured_command[0x01] == 0x0A  # the Unlock opcode
+    assert captured_command[0x04] == 0x0A  # the unlatch operation byte
+
+
+@pytest.mark.asyncio
+async def test_every_operation_names_the_budget_its_motion_needs() -> None:
+    """Each operation passes its own response budget; none is defaulted.
+
+    The budget is a property of the motion, so it is set where the operation
+    is issued rather than inherited from a signature: lock, unlock and
+    securemode move the lock, an unlatch also pulls the latch in and holds it
+    out. _execute_operation_command takes it as a required argument, which is
+    what makes an operation added later choose rather than inherit.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+    budgets: dict[str, float] = {}
+
+    async def _capture(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        budgets[command_name] = response_timeout
+
+    lock._execute_operation_command = _capture  # type: ignore[method-assign]
+
+    await lock.force_lock()
+    await lock.force_unlock()
+    await lock.force_securemode()
+    await lock.force_unlatch()
+
+    assert budgets == {
+        "force_lock": OPERATION_RESPONSE_TIMEOUT,
+        "force_unlock": OPERATION_RESPONSE_TIMEOUT,
+        "force_securemode": OPERATION_RESPONSE_TIMEOUT,
+        "force_unlatch": UNLATCH_OPERATION_RESPONSE_TIMEOUT,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unlatch_is_the_only_operation_that_skips_the_ack_wait() -> None:
+    """force_unlatch waits on its op-response alone; the other three keep the
+    acknowledgment stage.
+
+    The acknowledgment is an early delivery signal and it pays only where the
+    caller may re-send. Lock, unlock and securemode may, so a missing
+    acknowledgment should end their attempt early. An unlatch may not once its
+    command is written, and its op-response lands well past the acknowledgment
+    budget, so the stage could only end the operation while the latch was out.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+    waited: dict[str, bool] = {}
+
+    async def _capture(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        waited[command_name] = wait_for_ack
+
+    lock._execute_operation_command = _capture  # type: ignore[method-assign]
+
+    await lock.force_lock()
+    await lock.force_unlock()
+    await lock.force_securemode()
+    await lock.force_unlatch()
+
+    assert waited == {
+        "force_lock": True,
+        "force_unlock": True,
+        "force_securemode": True,
+        "force_unlatch": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_an_unlatch_completes_without_an_acknowledgment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unlatch whose acknowledgment never arrives completes on its op-response.
+
+    The lock acknowledges nothing here and its op-response lands past the
+    acknowledgment budget, well inside the unlatch's own. Only the skipped
+    stage reaching the session makes that exchange a success: with the stage
+    in place the attempt ends as a failure while the latch is out, and the
+    op-response the lock did send arrives with nothing waiting for it.
+    """
+    monkeypatch.setattr("yalexs_ble.session.ACK_TIMEOUT", 0.05)
+    lock = _make_connected_lock_with_session()
+    session = lock.session
+    assert session is not None
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._ack_future is not None)
+        await asyncio.sleep(0.12)
+        session._notify(0, bytearray(_op_response_frame(Commands.UNLOCK)))
+
+    feeder = asyncio.create_task(feed())
+    await lock.force_unlatch()
+    await feeder
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_failure_before_write_stays_retryable() -> None:
+    """A failure before the command write leaves write_attempted False, so the
+    error propagates unchanged and the caller may retry; the latch never fired.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    async def _fail(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        raise DisconnectedError("dropped before the write")
+
+    lock._execute_operation_command = _fail  # type: ignore[method-assign]
+    with pytest.raises(DisconnectedError):
+        await lock.force_unlatch()
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_failure_after_write_converts_to_unlatch_error() -> None:
+    """A retryable failure AFTER the command write converts to the non-retryable
+    UnlatchError: a repeated unlatch fires the latch again, so it must not retry.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    async def _fail(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        assert progress is not None
+        progress.write_attempted = True
+        raise TimeoutError("no op-response after the write")
+
+    lock._execute_operation_command = _fail  # type: ignore[method-assign]
+    with pytest.raises(UnlatchError) as excinfo:
+        await lock.force_unlatch()
+    # The originating error is preserved as the cause.
+    assert isinstance(excinfo.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_errored_write_converts_to_unlatch_error() -> None:
+    """A write call that errors leaves delivery unknown: the request PDU may
+    have reached the lock even though the write reported failure, so the
+    failure converts to the non-retryable UnlatchError instead of retrying.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    async def _fail(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        assert progress is not None
+        progress.write_attempted = True
+        raise BleakError("link dropped during the write")
+
+    lock._execute_operation_command = _fail  # type: ignore[method-assign]
+    with pytest.raises(UnlatchError) as excinfo:
+        await lock.force_unlatch()
+    # The originating error is preserved as the cause.
+    assert isinstance(excinfo.value.__cause__, BleakError)
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_converts_a_raising_write_through_the_session() -> None:
+    """A raising GATT write reaches the caller as UnlatchError, session included.
+
+    force_unlatch creates the OperationProgress and reads write_attempted off
+    it after the failure, so the instance it passes down has to be the one the
+    session marks at the write. With a separate instance below it, the failure
+    reads as one from before the write and the BleakError reaches the caller
+    unconverted and retryable.
+    """
+    lock = _make_connected_lock_with_session()
+    assert lock.client is not None
+    lock.client.write_gatt_char = AsyncMock(side_effect=BleakError("write failed"))
+
+    with pytest.raises(UnlatchError) as excinfo:
+        await lock.force_unlatch()
+    assert isinstance(excinfo.value.__cause__, BleakError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        EOFError("dbus socket closed"),
+        BrokenPipeError("dbus socket closed"),
+        AttributeError("backend went away mid-write"),
+        ValueError("an error from nowhere near the retry set"),
+    ],
+)
+async def test_force_unlatch_converts_every_post_write_failure(
+    error: Exception,
+) -> None:
+    """The post-write conversion is type-blind, so no failure can re-send.
+
+    Enumerating retryable types is what let this leak: the retry set is
+    assembled from bleak_retry_connector and grows without reference to this
+    guard. The first three of these were in that set and outside an earlier
+    enumeration, so a post-write escape would have been retried and the
+    latch fired twice; the fourth is in no retry set at all and converts,
+    which is the property that keeps the invariant true as the set widens.
+    """
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    async def _fail(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        assert progress is not None
+        progress.write_attempted = True
+        raise error
+
+    lock._execute_operation_command = _fail  # type: ignore[method-assign]
+    with pytest.raises(UnlatchError) as excinfo:
+        await lock.force_unlatch()
+    assert excinfo.value.__cause__ is error
+
+
+@pytest.mark.asyncio
+async def test_force_unlatch_operation_incomplete_is_not_converted() -> None:
+    """OperationIncompleteError is already non-retryable, so it propagates as
+    itself even after the write and is not re-wrapped as UnlatchError. The
+    identity assertion is what pins the passthrough clause: wrapping the type
+    would break it.
+    """
+    error = OperationIncompleteError("acked but no op-response")
+    lock = _make_lock()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    async def _fail(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float,
+        progress: OperationProgress | None = None,
+        write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
+    ) -> None:
+        assert progress is not None
+        progress.write_attempted = True
+        raise error
+
+    lock._execute_operation_command = _fail  # type: ignore[method-assign]
+    with pytest.raises(type(error)) as excinfo:
+        await lock.force_unlatch()
+    assert excinfo.value is error
+
+
+def test_unlatch_error_is_reachable_from_the_package_root() -> None:
+    """The type a caller has to catch is importable where callers import from.
+
+    Every test here takes it from yalexs_ble.session, so nothing else in the
+    suite would notice if the package-root export were dropped, and a consumer
+    catching it by the documented path would stop compiling.
+    """
+    assert yalexs_ble.UnlatchError is UnlatchError
+    assert "UnlatchError" in yalexs_ble.__all__

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -273,22 +273,18 @@ def test_parse_lock_status_decodes_the_unlatch_states(
     assert ("Unrecognized lock_status_str" in caplog.text) is diagnostic_logged
 
 
-def test_a_frame_value_matching_securing_is_unrecognized(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A frame carrying SECURING's value never decodes to the member.
+def test_no_status_byte_decodes_to_securing() -> None:
+    """No frame can decode to SECURING.
 
-    SECURING is library-synthesized and excluded from VALUE_TO_LOCK_STATUS,
-    so a frame carrying its byte cannot forge the securing stamp: it takes
-    the unrecognized-code path like any other value the lock does not
-    report.
+    Every decode site reads a single status byte, so a value above 0xFF is
+    out of a byte lookup's reach whatever VALUE_TO_LOCK_STATUS holds.
     """
     lock = _make_lock()
 
-    with caplog.at_level("INFO", logger="yalexs_ble.lock"):
-        assert lock._parse_lock_status(LockStatus.SECURING.value) is LockStatus.UNKNOWN
-
-    assert "Unrecognized lock_status_str" in caplog.text
+    assert all(
+        lock._parse_lock_status(value) is not LockStatus.SECURING
+        for value in range(0x100)
+    )
 
 
 def test_parse_success_op_response_with_0200_trailer_is_no_update(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1416,18 +1416,22 @@ async def test_public_unlatch_wrapper_runs_force_unlatch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_unlatch_grants_the_extended_op_response_budget() -> None:
-    """Unlatch gets the longer op-response budget because it is a longer motion.
+async def test_force_unlatch_passes_its_own_op_response_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unlatch passes its own op-response budget and the unlatch encoding.
 
-    force_unlatch passes UNLATCH_OPERATION_RESPONSE_TIMEOUT, and encodes
+    The budget is a separate tuning point so the unlatch can be tuned on
+    its own without moving the other operations, held at the plain value
+    today; the constant is patched to a distinct value here because equal
+    constants cannot show which one is passed. force_unlatch encodes
     unlatch as the Unlock opcode with the unlatch operation byte (there is
     no dedicated unlatch opcode).
 
     The opcode and operation byte are asserted against the wire values, not
     against the constants that produced them: #351 sent operation byte 0x01.
-    The budget is asserted to exceed the plain one, the property the
-    extension exists for.
     """
+    monkeypatch.setattr("yalexs_ble.lock.UNLATCH_OPERATION_RESPONSE_TIMEOUT", 21.5)
     lock = _make_lock()
     session = MagicMock()
 
@@ -1460,8 +1464,7 @@ async def test_force_unlatch_grants_the_extended_op_response_budget() -> None:
     lock._execute_operation_command = _capture  # type: ignore[method-assign]
 
     await lock.force_unlatch()
-    assert captured_timeout == UNLATCH_OPERATION_RESPONSE_TIMEOUT
-    assert UNLATCH_OPERATION_RESPONSE_TIMEOUT > OPERATION_RESPONSE_TIMEOUT
+    assert captured_timeout == 21.5
     assert captured_command is not None
     assert captured_command[0x01] == 0x0A  # the Unlock opcode
     assert captured_command[0x04] == 0x0A  # the unlatch operation byte
@@ -1469,13 +1472,13 @@ async def test_force_unlatch_grants_the_extended_op_response_budget() -> None:
 
 @pytest.mark.asyncio
 async def test_every_operation_names_the_budget_its_motion_needs() -> None:
-    """Each operation passes its own response budget; none is defaulted.
+    """Each operation passes a budget explicitly; none inherits one.
 
-    The budget is a property of the motion, so it is set where the operation
-    is issued rather than inherited from a signature: lock, unlock and
-    securemode move the lock, an unlatch also pulls the latch in and holds it
-    out. _execute_operation_command takes it as a required argument, which is
-    what makes an operation added later choose rather than inherit.
+    _execute_operation_command takes the budget as a required argument, so an
+    operation added later has to choose one. The unlatch budget and the plain
+    budget carry the same value today, so which constant force_unlatch reads
+    is pinned by test_force_unlatch_passes_its_own_op_response_budget, which
+    patches it to a distinct value.
     """
     lock = _make_lock()
     lock.session = MagicMock()
@@ -1515,9 +1518,9 @@ async def test_unlatch_is_the_only_operation_that_skips_the_ack_wait() -> None:
 
     The acknowledgment is an early delivery signal and it pays only where the
     caller may re-send. Lock, unlock and securemode may, so a missing
-    acknowledgment should end their attempt early. An unlatch may not once its
-    command is written, and its op-response lands well past the acknowledgment
-    budget, so the stage could only end the operation while the latch was out.
+    acknowledgment should end their attempt early. An unlatch may not once
+    its command is written, so a missing acknowledgment must not end an
+    attempt whose op-response could still arrive.
     """
     lock = _make_lock()
     lock.session = MagicMock()
@@ -1557,7 +1560,7 @@ async def test_an_unlatch_completes_without_an_acknowledgment(
     """An unlatch whose acknowledgment never arrives completes on its op-response.
 
     The lock acknowledges nothing here and its op-response lands past the
-    acknowledgment budget, well inside the unlatch's own. Only the skipped
+    acknowledgment budget, inside the operation budget. Only the skipped
     stage reaching the session makes that exchange a success: with the stage
     in place the attempt ends as a failure while the latch is out, and the
     op-response the lock did send arrives with nothing waiting for it.

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1555,7 +1555,7 @@ async def test_unlatch_is_the_only_operation_that_skips_the_ack_wait() -> None:
 
 @pytest.mark.asyncio
 async def test_an_unlatch_completes_without_an_acknowledgment(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """An unlatch whose acknowledgment never arrives completes on its op-response.
 
@@ -1563,7 +1563,9 @@ async def test_an_unlatch_completes_without_an_acknowledgment(
     acknowledgment budget, inside the operation budget. Only the skipped
     stage reaching the session makes that exchange a success: with the stage
     in place the attempt ends as a failure while the latch is out, and the
-    op-response the lock did send arrives with nothing waiting for it.
+    op-response the lock did send arrives with nothing waiting for it. The
+    missing acknowledgment is still logged, the same line every operation
+    gets, so the field log keeps its one trace of the case.
     """
     monkeypatch.setattr("yalexs_ble.session.ACK_TIMEOUT", 0.05)
     lock = _make_connected_lock_with_session()
@@ -1576,8 +1578,11 @@ async def test_an_unlatch_completes_without_an_acknowledgment(
         session._notify(0, bytearray(_op_response_frame(Commands.UNLOCK)))
 
     feeder = asyncio.create_task(feed())
-    await lock.force_unlatch()
+    with caplog.at_level("INFO", logger="yalexs_ble.session"):
+        await lock.force_unlatch()
     await feeder
+
+    assert "completed on its op-response; no acknowledgment was received" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -20,6 +20,7 @@ from yalexs_ble.const import (
     LockInfo,
     LockState,
     LockStatus,
+    OperationError,
 )
 from yalexs_ble.lock import Lock
 from yalexs_ble.push import (
@@ -2760,6 +2761,9 @@ async def test_execute_lock_operation_success_stamps_complete_state() -> None:
     push_lock = _operational_push_lock()
     mock_lock = MagicMock()
     mock_lock.force_lock = AsyncMock()
+    # The result byte a successful op-response leaves behind; the stamp
+    # reads it before applying the completed state.
+    mock_lock._last_op_error = OperationError.COMM_SUCCESS
 
     with patch.object(
         push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
@@ -2768,6 +2772,33 @@ async def test_execute_lock_operation_success_stamps_complete_state() -> None:
 
     mock_lock.force_lock.assert_awaited_once()
     assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_a_reported_operation_failure_leaves_jammed_on_display() -> None:
+    """A failure op-response's JAMMED is not overwritten by the commanded state.
+
+    The parser publishes JAMMED from the op-response before force_* returns,
+    so the completed-state stamp applies only when the lock reported success.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:37")
+    mock_lock = MagicMock()
+
+    async def _force_lock_jams() -> None:
+        # What a failure op-response does inside the notify callback: the
+        # parser records the result byte and publishes JAMMED, then the wait
+        # resolves and force_lock returns normally.
+        mock_lock._last_op_error = OperationError.MECH_POSITION
+        push_lock._state_callback([LockStatus.JAMMED])
+
+    mock_lock.force_lock = AsyncMock(side_effect=_force_lock_jams)
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.JAMMED
 
 
 @pytest.mark.asyncio

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -11,6 +11,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakDBusError, BleakError
 
+import yalexs_ble
 from yalexs_ble.const import (
     AuthState,
     AutoLockMode,
@@ -20,7 +21,6 @@ from yalexs_ble.const import (
     LockInfo,
     LockState,
     LockStatus,
-    OperationError,
 )
 from yalexs_ble.lock import Lock
 from yalexs_ble.push import (
@@ -37,6 +37,7 @@ from yalexs_ble.push import (
     DEADLINE_WAKEUP_RETRY_DELAY,
     DEFAULT_ATTEMPTS,
     HAP_FIRST_BYTE,
+    KEEP_ALIVE_TIME,
     LOCK_STALE_STATE_DEBOUNCE_DELAY,
     NEVER_TIME,
     NO_BATTERY_SUPPORT_MODELS,
@@ -2751,54 +2752,66 @@ def _operational_push_lock(address: str = "aa:bb:cc:dd:ee:50") -> PushLock:
     return push_lock
 
 
+def _known_state(lock: LockStatus, door: DoorStatus = DoorStatus.CLOSED) -> LockState:
+    """A settled cycle state, so an operation starts from a known position."""
+    return LockState(
+        lock=lock,
+        door=door,
+        battery=None,
+        auth=None,
+        auto_lock=None,
+        auto_lock_prev=None,
+    )
+
+
 @pytest.mark.asyncio
-async def test_execute_lock_operation_success_stamps_complete_state() -> None:
+@pytest.mark.parametrize(
+    ("method", "op_attr", "complete_state"),
+    [
+        ("lock", "force_lock", LockStatus.LOCKED),
+        ("unlock", "force_unlock", LockStatus.UNLOCKED),
+        ("securemode", "force_securemode", LockStatus.SECUREMODE),
+    ],
+)
+async def test_execute_lock_operation_success_stamps_complete_state(
+    method: str, op_attr: str, complete_state: LockStatus
+) -> None:
     """A completed force_* advances the state to the completed status.
 
-    Drives lock() to completion: the transitional LOCKING is stamped, the
-    operation returns, and the completed LOCKED status is applied.
+    Drives each public operation to completion: the transitional is stamped,
+    the operation returns, and the completed status is applied.
     """
     push_lock = _operational_push_lock()
     mock_lock = MagicMock()
-    mock_lock.force_lock = AsyncMock()
-    # The result byte a successful op-response leaves behind; the stamp
-    # reads it before applying the completed state.
-    mock_lock._last_op_error = OperationError.COMM_SUCCESS
+    setattr(mock_lock, op_attr, AsyncMock())
 
     with patch.object(
         push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
     ):
-        await push_lock.lock()
+        await getattr(push_lock, method)()
 
-    mock_lock.force_lock.assert_awaited_once()
-    assert push_lock.lock_status == LockStatus.LOCKED
+    getattr(mock_lock, op_attr).assert_awaited_once()
+    assert push_lock.lock_status == complete_state
 
 
 @pytest.mark.asyncio
-async def test_a_reported_operation_failure_leaves_jammed_on_display() -> None:
-    """A failure op-response's JAMMED is not overwritten by the commanded state.
+async def test_deferred_update_defers_inside_the_stale_state_window() -> None:
+    """An update landing right after an operation completes is rescheduled.
 
-    The parser publishes JAMMED from the op-response before force_* returns,
-    so the completed-state stamp applies only when the lock reported success.
+    The lock's reported state is still settling for the debounce delay after
+    the op-response, so a lock polled now would report a stale state. The
+    cycle is re-armed for the time the floor has left and starts no update
+    task.
     """
-    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:37")
-    mock_lock = MagicMock()
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:51")
+    push_lock._earliest_update_time = time.monotonic() + LOCK_STALE_STATE_DEBOUNCE_DELAY
 
-    async def _force_lock_jams() -> None:
-        # What a failure op-response does inside the notify callback: the
-        # parser records the result byte and publishes JAMMED, then the wait
-        # resolves and force_lock returns normally.
-        mock_lock._last_op_error = OperationError.MECH_POSITION
-        push_lock._state_callback([LockStatus.JAMMED])
+    with patch.object(push_lock, "_schedule_future_update") as mock_reschedule:
+        push_lock._deferred_update()
 
-    mock_lock.force_lock = AsyncMock(side_effect=_force_lock_jams)
-
-    with patch.object(
-        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
-    ):
-        await push_lock.lock()
-
-    assert push_lock.lock_status == LockStatus.JAMMED
+    mock_reschedule.assert_called_once()
+    assert 0 < mock_reschedule.call_args.args[0] <= LOCK_STALE_STATE_DEBOUNCE_DELAY
+    assert push_lock._update_task is None
 
 
 @pytest.mark.asyncio
@@ -2806,9 +2819,9 @@ async def test_failed_operation_anchors_the_stale_state_debounce() -> None:
     """A failed force_* holds the next cycle off as a completed one does.
 
     The command reached the lock, so the motor may have run and the position
-    is unknown rather than unchanged. The failed attempt stamps the anchor a
-    completed one stamps, and a cycle falling due inside the debounce that
-    follows is rescheduled rather than run.
+    is unknown rather than unchanged. The operation's exit moves the floor
+    whether it completed or failed, and a cycle falling due before the floor
+    re-arms for the remainder rather than polling.
     """
     push_lock = _operational_push_lock("aa:bb:cc:dd:ee:39")
     mock_lock = MagicMock()
@@ -2824,31 +2837,27 @@ async def test_failed_operation_anchors_the_stale_state_debounce() -> None:
 
     assert push_lock.lock_status == LockStatus.UNKNOWN
 
-    with patch.object(
-        push_lock, "_schedule_future_update_with_debounce"
-    ) as mock_reschedule:
+    with patch.object(push_lock, "_schedule_future_update") as mock_reschedule:
         push_lock._deferred_update()
 
     assert push_lock._update_task is None
     (delay,) = mock_reschedule.call_args.args
-    assert delay < LOCK_STALE_STATE_DEBOUNCE_DELAY
+    assert 0 < delay <= LOCK_STALE_STATE_DEBOUNCE_DELAY
 
 
 @pytest.mark.asyncio
 async def test_deferred_update_backs_off_while_an_operation_holds_the_lock() -> None:
     """A cycle falling due mid-operation backs off rather than queueing.
 
-    The stale-state debounce is measured from the last operation to have
-    finished, so an operation still running passes it. Creating the cycle
-    there would put it behind the operation lock, and it would read the lock
-    the moment the operation released it, inside the window the debounce
-    exists to keep it out of.
+    The floor can lapse while the motion is still running, and a cycle
+    created there would wait on the operation lock and poll the lock the
+    moment the operation released it, inside the post-operation debounce delay
+    the operation is about to stamp.
     """
     push_lock = _operational_push_lock("aa:bb:cc:dd:ee:38")
-    # The previous operation's anchor is old enough that the debounce passes.
-    push_lock._last_lock_operation_complete_time = (
-        time.monotonic() - LOCK_STALE_STATE_DEBOUNCE_DELAY - 1
-    )
+    # The floor has lapsed, so only the operation lock is left to hold the
+    # cycle off.
+    push_lock._earliest_update_time = time.monotonic() - 1.0
 
     await push_lock._operation_lock.acquire()
     try:
@@ -2861,3 +2870,1554 @@ async def test_deferred_update_backs_off_while_an_operation_holds_the_lock() -> 
 
     assert push_lock._update_task is None
     mock_reschedule.assert_called_once_with(DEADLINE_WAKEUP_RETRY_DELAY)
+
+
+@pytest.mark.asyncio
+async def test_lock_stamps_transitional_only_at_write_success():
+    """The LOCKING transitional is stamped only when the command write reaches
+    the lock (write-success), never at issue time, and exactly once."""
+    push_lock = _operational_push_lock()
+    order: list[tuple[str, LockStatus | None]] = []
+
+    def cb(lock_state, lock_info, connection_info):
+        order.append(("state", lock_state.lock))
+
+    push_lock.register_callback(cb)
+
+    mock_lock = MagicMock()
+
+    async def force_lock(write_success_callback):
+        order.append(("write_success", None))
+        write_success_callback()
+
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    # No state was emitted before the write reached the lock.
+    first_state_index = next(i for i, ev in enumerate(order) if ev[0] == "state")
+    assert first_state_index > order.index(("write_success", None))
+    # Exactly one LOCKING stamp, then LOCKED on completion.
+    assert [ev for ev in order if ev == ("state", LockStatus.LOCKING)] == [
+        ("state", LockStatus.LOCKING)
+    ]
+    assert order[-1] == ("state", LockStatus.LOCKED)
+    assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_write_success_without_pending_state_stamps_nothing():
+    """A write-success with no pending transitional stamps no state.
+
+    Every gated operation arms a pending transitional before its write, so the
+    stamp's guard never sees None on any in-repo path; this pins the guard's
+    other arc. The window itself still opens: opening is unconditional at the
+    write-success site.
+    """
+    push_lock = _operational_push_lock()
+    events: list[LockState] = []
+    push_lock.register_callback(
+        lambda lock_state, lock_info, connection_info: events.append(lock_state)
+    )
+    assert push_lock._pending_op_state is None
+
+    push_lock._operation_write_success()
+
+    assert events == []
+    assert push_lock._operation_window_open is True
+
+
+@pytest.mark.asyncio
+async def test_window_filters_foreign_settle_until_close():
+    """While the operation window is open a foreign lock-status settle is
+    dropped; once the window closes the same value is admitted."""
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    push_lock._operation_window_open = True
+    push_lock._update_any_state([LockStatus.LOCKED])
+    assert push_lock.lock_status == LockStatus.UNLOCKED  # dropped mid-window
+
+    push_lock._close_operation_window()
+    push_lock._update_any_state([LockStatus.LOCKED])
+    assert push_lock.lock_status == LockStatus.LOCKED  # admitted after close
+
+
+@pytest.mark.asyncio
+async def test_window_admits_the_door_member():
+    """Only the lock member of a call is filtered mid-window.
+
+    The filter runs on the lock status alone, so a door member handled in the
+    same call still reaches the display, which is what a door event arriving
+    during an operation needs.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._operation_window_open = True
+
+    push_lock._update_any_state([DoorStatus.OPENED, LockStatus.LOCKED])
+
+    assert push_lock.door_status == DoorStatus.OPENED  # door applied
+    assert push_lock.lock_status == LockStatus.UNLOCKED  # lock filtered
+
+
+@pytest.mark.asyncio
+async def test_a_recorded_outcome_stands_when_the_operation_fails() -> None:
+    """The arm stamps the unknown position only over a blank record.
+
+    An operation that recorded what the lock reported has an answer already,
+    and it is a better one than the unknown position, so a failure on the way
+    out leaves it alone. The record is seeded by hand here to pin the arm's
+    other branch.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:6b")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()
+        push_lock._operation_outcome = LockStatus.LOCKED
+        raise OperationIncompleteError("no op-response")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status is LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_early_error_before_write_leaves_no_window_and_stamps_unknown():
+    """A retryable failure before the command write opens no window and stamps
+    UNKNOWN.
+
+    The write-success hook fires when the lock's ATT server takes the command
+    bytes, so this failure covers a command that never left the radio and a
+    command that was delivered with its write response lost. The position the
+    display held before the operation is not what either case leaves behind.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(
+        side_effect=DisconnectedError("dropped before write")
+    )
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(DisconnectedError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._operation_window_open is False
+    assert push_lock._pending_op_state is None
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_after_write_stamps_unknown():
+    """A non-retryable failure raised after write-success (a transitional is on
+    display with no result coming) closes the window and stamps UNKNOWN."""
+    exc = OperationIncompleteError("no op-response")
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    mock_lock = MagicMock()
+
+    async def force_lock(write_success_callback):
+        write_success_callback()  # opens window, stamps LOCKING
+        raise exc
+
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(type(exc)),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._operation_window_open is False
+    assert push_lock._pending_op_state is None
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_queued_second_operation_waits_for_the_first_to_settle():
+    """A second operation queued mid-flight runs only after the first settles.
+
+    The operation lock covers _run_lock_operation whole, so the queued caller
+    waits: the first operation's terminal failure after write-success stamps
+    UNKNOWN, and the second operation then runs from that display.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:5c")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    states: list[LockStatus] = []
+
+    def cb(lock_state, lock_info, connection_info):
+        states.append(lock_state.lock)
+
+    push_lock.register_callback(cb)
+
+    proceed = asyncio.Event()
+    first_attempt = True
+
+    async def force_lock(write_success_callback):
+        nonlocal first_attempt
+        if first_attempt:
+            first_attempt = False
+            write_success_callback()  # opens window, stamps LOCKING
+            await proceed.wait()
+            raise OperationIncompleteError("no op-response")
+        write_success_callback()  # the second operation succeeds
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        first = asyncio.create_task(push_lock.lock())
+        await asyncio.sleep(0)  # the first operation is past write-success
+        second = asyncio.create_task(push_lock.lock())
+        await asyncio.sleep(0)  # the second caller queues on the operation lock
+        proceed.set()
+        with pytest.raises(OperationIncompleteError):
+            await first
+        await second
+
+    assert states == [
+        LockStatus.LOCKING,
+        LockStatus.UNKNOWN,
+        LockStatus.LOCKING,
+        LockStatus.LOCKED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_queued_operation_leaves_the_window_alone():
+    """A queued operation cancelled while waiting changes nothing.
+
+    The cancel lands in the lock acquisition, ahead of the method body, so
+    the cancelled caller runs neither the record reset nor _finalize_operation:
+    the first operation keeps its window open and completes normally.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:2c")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    proceed = asyncio.Event()
+
+    async def force_lock(write_success_callback):
+        write_success_callback()  # opens window, stamps LOCKING
+        await proceed.wait()
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        first = asyncio.create_task(push_lock.lock())
+        await asyncio.sleep(0)  # the first operation is past write-success
+        second = asyncio.create_task(push_lock.lock())
+        await asyncio.sleep(0)  # the second caller queues on the operation lock
+        second.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second
+        assert push_lock._operation_window_open is True
+        assert push_lock._pending_op_state == LockStatus.LOCKING
+        proceed.set()
+        await first
+
+    assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_retry_restamps_at_write_success_without_unknown():
+    """A retryable failure after write-success keeps the last transitional on
+    display (never UNKNOWN); the next attempt re-sets the pending transitional
+    and re-stamps at its own write-success."""
+    push_lock = _operational_push_lock()
+    events: list[LockStatus] = []
+
+    def cb(lock_state, lock_info, connection_info):
+        events.append(lock_state.lock)
+
+    push_lock.register_callback(cb)
+
+    pending_at_entry: list[LockStatus | None] = []
+    attempts = 0
+
+    async def force_lock(write_success_callback):
+        nonlocal attempts
+        attempts += 1
+        pending_at_entry.append(push_lock._pending_op_state)
+        write_success_callback()  # opens window, stamps LOCKING
+        if attempts == 1:
+            raise DisconnectedError("dropped before ack")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+    ):
+        await push_lock.lock()
+
+    assert attempts == 2  # first attempt was retried
+    # Each attempt re-set the pending transitional before its write.
+    assert pending_at_entry == [LockStatus.LOCKING, LockStatus.LOCKING]
+    # Never UNKNOWN; LOCKING once (the second stamp is a no-op since the
+    # display already reads LOCKING) then LOCKED.
+    assert LockStatus.UNKNOWN not in events
+    assert events == [LockStatus.LOCKING, LockStatus.LOCKED]
+    assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_a_settled_status_between_attempts_reaches_the_display():
+    """A settled reading delivered between attempts reaches the display.
+
+    A retryable failure closes the operation window on its way to the retry,
+    so between attempts the display is open to the lock's own reporting; the
+    next attempt opens a window of its own at its write-success. Without the
+    close on the retryable exit the first attempt's window would span the
+    gap and filter this reading.
+    """
+    push_lock = _operational_push_lock()
+    events: list[LockStatus] = []
+
+    def cb(lock_state, lock_info, connection_info):
+        events.append(lock_state.lock)
+
+    push_lock.register_callback(cb)
+
+    attempts = 0
+
+    async def force_lock(write_success_callback):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            write_success_callback()  # opens the window, stamps LOCKING
+            raise DisconnectedError("dropped before ack")
+        # This runs between the failure above and this attempt's write, where
+        # the window is closed and a settled reading is admitted.
+        push_lock._update_any_state([LockStatus.LOCKED])
+        write_success_callback()
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+    ):
+        await push_lock.lock()
+
+    assert attempts == 2
+    assert events == [
+        LockStatus.LOCKING,
+        LockStatus.LOCKED,
+        LockStatus.LOCKING,
+        LockStatus.LOCKED,
+    ]
+    assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_a_failure_before_any_write_replaces_a_reported_transitional():
+    """What the display holds does not decide the unknown position.
+
+    An operation started at the lock has it pushing UNLOCKING and the display
+    holding it, and our unlock() then fails before its command write. The
+    reading is real and the lock's own result is still coming, and the stamp
+    lands on it anyway: a failed operation of ours reports that we cannot say
+    where the mechanism is, whatever the display was showing.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKING)
+
+    mock_lock = MagicMock()
+    mock_lock.force_unlock = AsyncMock(
+        side_effect=OperationIncompleteError("before write")
+    )
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.unlock()
+
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_an_operation_settling_after_the_stop_arms_nothing():
+    """An operation ending after the watcher stopped leaves no timer behind.
+
+    _cancel does not reach an operation in flight, so _finalize_operation runs
+    once the operation fails on its own. The window is closed either way, but
+    scheduling the status poll would arm a cycle holding the lock past the stop
+    with nothing left to run it.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def _stop_then_fail(write_success_callback):
+        write_success_callback()
+        push_lock._running = False
+        raise OperationIncompleteError("no op-response, and we were stopped")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(side_effect=_stop_then_fail)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._operation_window_open is False
+    assert push_lock._cancel_deferred_update is None
+    # The unknown position _finalize_operation would otherwise have applied.
+    assert push_lock.lock_status == LockStatus.LOCKING
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_a_jam_recorded_before_the_stop_reaches_no_later_operation():
+    """A stopped operation discharges the jam record instead of leaving it set.
+
+    _finalize_operation returns before it can apply the outcome, so the window
+    closing is what clears the record. Were it left set, the next operation on this
+    instance would find a jam from the stopped session and end its attempt
+    ladder as OperationIncompleteError, displaying JAMMED for a mechanism the
+    new command never reached.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:2d")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def _jam_then_stop_then_fail(write_success_callback):
+        write_success_callback()
+        # Filtered by the open window, so the operation carries the record.
+        push_lock._update_any_state([LockStatus.JAMMED])
+        push_lock._running = False
+        raise OperationIncompleteError("no op-response, and we were stopped")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(side_effect=_jam_then_stop_then_fail)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._seen_intervention_status is None
+
+    # Started again, an operation that fails before its write-success keeps its
+    # own retryable failure and stamps the unknown position; a leaked record
+    # would raise OperationIncompleteError and display JAMMED instead.
+    push_lock._running = True
+    with (
+        patch.object(
+            push_lock,
+            "_ensure_connected",
+            AsyncMock(side_effect=DisconnectedError("no link")),
+        ),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(DisconnectedError),
+    ):
+        await push_lock.unlock()
+
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_jam_inside_the_window_outranks_a_successful_result() -> None:
+    """A jam received while the window is open reaches the display.
+
+    The filter drops the jam like every other status, but it is recorded, and
+    the operation applies it at its exit in place of the complete_state its
+    own command implies: the target state is inferred, the jam is a reading of
+    where the mechanism stopped.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    mock_lock = MagicMock()
+
+    async def force_lock(write_success_callback):
+        write_success_callback()  # opens window, stamps LOCKING
+        push_lock._update_any_state([LockStatus.JAMMED])
+        assert push_lock.lock_status == LockStatus.LOCKING  # dropped mid-window
+
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.JAMMED
+    assert push_lock._seen_intervention_status is None  # cleared when the window closed
+
+
+def test_manual_intervention_statuses_is_public_and_complete() -> None:
+    """The set is importable from the package and names all three statuses.
+
+    Home Assistant maps calibration, polarity discovery and a jam onto one
+    jammed attribute, and enumerates the three members itself today. This is
+    the name it can import instead, so the membership is pinned here rather
+    than left to whoever next edits the status table.
+    """
+    assert {
+        LockStatus.UNKNOWN_01,
+        LockStatus.UNKNOWN_06,
+        LockStatus.JAMMED,
+    } == yalexs_ble.MANUAL_INTERVENTION_STATUSES
+    assert "MANUAL_INTERVENTION_STATUSES" in yalexs_ble.__all__
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup_condition",
+    [LockStatus.UNKNOWN_01, LockStatus.UNKNOWN_06],
+)
+async def test_a_setup_condition_inside_the_window_reaches_the_display(
+    setup_condition: LockStatus,
+) -> None:
+    """Calibration and polarity discovery survive the window as a jam does.
+
+    The filter exists to keep mid-motion readings off the display, and the
+    op-response is a true picture of where the mechanism stopped. Neither
+    argument covers a lock that reports it needs setting up: that is not a
+    transient reading, the op-response says nothing about it, and discarding
+    it would leave the condition invisible until some later frame carried it
+    again. So it is recorded like a jam and applied at the operation's exit.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    mock_lock = MagicMock()
+
+    async def force_lock(write_success_callback):
+        write_success_callback()  # opens window, stamps LOCKING
+        push_lock._update_any_state([setup_condition])
+        assert push_lock.lock_status == LockStatus.LOCKING  # dropped mid-window
+
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    # The reported condition itself, not a stand-in: a consumer reads
+    # MANUAL_INTERVENTION_STATUSES to decide how to present it.
+    assert push_lock.lock_status is setup_condition
+    assert push_lock._seen_intervention_status is None  # cleared when the window closed
+
+
+@pytest.mark.asyncio
+async def test_jam_inside_the_window_replaces_the_unknown_of_a_lost_result() -> None:
+    """A result that never arrives settles on UNKNOWN, unless a jam was
+    reported inside the window: a position beats an unknown position."""
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    mock_lock = MagicMock()
+
+    async def force_lock(write_success_callback):
+        write_success_callback()
+        push_lock._update_any_state([LockStatus.JAMMED])
+        raise OperationIncompleteError("no op-response")
+
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.JAMMED
+    assert push_lock._operation_window_open is False
+    assert push_lock._seen_intervention_status is None
+
+
+@pytest.mark.asyncio
+async def test_jam_inside_the_window_ends_the_attempt_ladder() -> None:
+    """A retryable failure after a jam was reported does not re-send.
+
+    The retryable types mean the command may never have been delivered, so the
+    next attempt would write it again and drive the motor into a mechanism the
+    lock has just reported jammed. The attempt ladder ends instead, with the
+    jam on display and OperationIncompleteError to the caller.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    attempts = 0
+
+    async def force_lock(write_success_callback):
+        nonlocal attempts
+        attempts += 1
+        write_success_callback()
+        push_lock._update_any_state([LockStatus.JAMMED])
+        raise DisconnectedError("dropped after the jam was reported")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert attempts == 1  # the command was written once, and not again
+    assert push_lock.lock_status == LockStatus.JAMMED
+    assert push_lock._operation_window_open is False
+    assert push_lock._seen_intervention_status is None
+
+
+@pytest.mark.asyncio
+async def test_a_new_commands_write_success_clears_the_jam_record() -> None:
+    """A command that reaches the lock supersedes a jam still on record.
+
+    Every operation exit applies a status it recorded, so no exit leaves
+    _seen_intervention_status set for the next command to find. The record is
+    seeded by hand here to pin the backstop: were one ever to reach a
+    write-success, the command the caller issued after the jam is the
+    intervention that status calls for, and its own result is what the display
+    carries.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.JAMMED)
+    push_lock._seen_intervention_status = LockStatus.JAMMED
+    seen_at_write_success: list[LockStatus | None] = []
+
+    async def force_unlock(write_success_callback):
+        write_success_callback()
+        seen_at_write_success.append(push_lock._seen_intervention_status)
+
+    mock_lock = MagicMock()
+    mock_lock.force_unlock = force_unlock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.unlock()
+
+    assert seen_at_write_success == [None]
+    assert push_lock.lock_status == LockStatus.UNLOCKED
+
+
+@pytest.mark.asyncio
+async def test_queued_operation_emits_no_transitional_until_dequeued() -> None:
+    """A second operation queued on the operation lock stamps nothing.
+
+    With the first operation in flight, force_lock blocked on an Event, a
+    second lock() is issued. While it waits on the operation lock it emits no
+    transitional; its LOCKING appears only after the first operation's
+    completed state.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:3a")
+    emissions: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: emissions.append(ls.lock))
+
+    gate = asyncio.Event()
+    calls = 0
+
+    async def gated_force_lock(write_success_callback: Callable[[], None]) -> None:
+        nonlocal calls
+        calls += 1
+        write_success_callback()
+        if calls == 1:
+            await gate.wait()  # hold op1 open while op2 queues behind it
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = gated_force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update"),
+    ):
+        op1 = asyncio.create_task(push_lock.lock())
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if emissions:
+                break
+        # op1 has stamped its single LOCKING at write-success.
+        assert emissions == [LockStatus.LOCKING]
+
+        op2 = asyncio.create_task(push_lock.lock())
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # op2 is queued on the operation lock: no transitional while queued.
+        assert emissions == [LockStatus.LOCKING]
+
+        gate.set()
+        await op1
+        await op2
+
+    # op2's LOCKING appears only AFTER op1's completion state (LOCKED).
+    assert emissions == [
+        LockStatus.LOCKING,
+        LockStatus.LOCKED,
+        LockStatus.LOCKING,
+        LockStatus.LOCKED,
+    ]
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_window_filter_drops_lock_status_admits_the_door_member() -> None:
+    """Literal filter opened via write-success: even mid-window JAMMED is dropped.
+
+    Distinct from the existing window tests (which set the flag directly and do
+    not feed JAMMED): the window is opened through the real
+    _operation_write_success path, and mid-window JAMMED is dropped with NO
+    special-casing, while the door member of the same frame still passes.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:3b")
+
+    # Open the window as write-success would: stamp the pending transitional.
+    push_lock._pending_op_state = LockStatus.LOCKING
+    push_lock._operation_write_success()
+    assert push_lock.lock_status is LockStatus.LOCKING
+    assert push_lock._operation_window_open is True
+
+    # A foreign settle mid-window is dropped (literal filter).
+    push_lock._update_any_state([LockStatus.LOCKED])
+    assert push_lock.lock_status is LockStatus.LOCKING
+
+    # Foreign jam evidence mid-window is dropped too, with no special-casing.
+    push_lock._update_any_state([LockStatus.JAMMED])
+    assert push_lock.lock_status is LockStatus.LOCKING
+
+    # A door event is the one status the lock sends during an operation, and it
+    # still reaches the display: only the lock member goes through
+    # _admit_lock_status.
+    push_lock._update_any_state([DoorStatus.OPENED])
+    assert push_lock.door_status is DoorStatus.OPENED
+
+
+@pytest.mark.asyncio
+async def test_early_disconnect_retries_to_exhaustion_then_stamps_unknown() -> None:
+    """A retryable disconnect before any write-success retries to exhaustion.
+
+    Distinct from the existing early-error test (which checks only the final
+    display): this pins the retry COUNT, force_lock re-sent exactly
+    DEFAULT_ATTEMPTS times because the write never reached the lock, and the
+    single emission the whole operation produces, the UNKNOWN of the exhausted
+    attempts with no transitional ahead of it.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:3c")
+    # Seed a settled position: the fixture starts at UNKNOWN, where the stamp
+    # would change nothing and emit nothing.
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+    emissions: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: emissions.append(ls.lock))
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(side_effect=DisconnectedError("boom"))
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update"),
+        patch.object(push_lock, "_async_handle_disconnected", AsyncMock()),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(DisconnectedError),
+    ):
+        await push_lock.lock()
+
+    # Retried to exhaustion (each attempt re-sends because the write never
+    # reached the lock)...
+    assert mock_lock.force_lock.await_count == DEFAULT_ATTEMPTS
+    # ...and the operation emitted once, at the end: no write, so no
+    # transitional, and the exhausted attempts leave the position unknown.
+    assert emissions == [LockStatus.UNKNOWN]
+    assert push_lock.lock_status is LockStatus.UNKNOWN
+    assert push_lock._operation_window_open is False
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_operation_incomplete_after_write_success_stamps_unknown_once() -> None:
+    """OperationIncompleteError after write-success: exact emission order, no retry.
+
+    Distinct from the existing non-retryable test (which checks only the final
+    display): this pins the full emission SEQUENCE [LOCKING, UNKNOWN] and that
+    the non-retryable error ran force_lock exactly once.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:3d")
+    emissions: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: emissions.append(ls.lock))
+
+    def force_lock_side_effect(write_success_callback: Callable[[], None]) -> None:
+        # The write reached the lock (window opens, LOCKING on display) but the
+        # result never arrived.
+        write_success_callback()
+        raise OperationIncompleteError("no op-response")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(side_effect=force_lock_side_effect)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update"),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    # Non-retryable: force_lock ran exactly once.
+    assert mock_lock.force_lock.await_count == 1
+    # LOCKING at write-success, then UNKNOWN when the result never came.
+    assert emissions == [LockStatus.LOCKING, LockStatus.UNKNOWN]
+    assert push_lock.lock_status is LockStatus.UNKNOWN
+    assert push_lock._operation_window_open is False
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_a_retryable_failure_disconnects_before_the_retry() -> None:
+    """A retryable failure tears the session down before the backoff sleep.
+
+    The retry arm awaits _async_handle_disconnected before it sleeps the
+    backoff and re-enters the operation, so the gap between attempts has no
+    session to deliver a frame.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:68")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    attempts = 0
+    order: list[str] = []
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        nonlocal attempts
+        attempts += 1
+        order.append(f"attempt {attempts}")
+        if attempts == 1:
+            write_success_callback()
+            raise DisconnectedError("dropped after the write")
+        raise OperationIncompleteError("no op-response")
+
+    async def record_teardown(_exc: Exception) -> None:
+        order.append("teardown")
+
+    async def record_backoff(_delay: float) -> None:
+        order.append("backoff")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update"),
+        patch.object(
+            push_lock,
+            "_async_handle_disconnected",
+            AsyncMock(side_effect=record_teardown),
+        ),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock(side_effect=record_backoff)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert order == ["attempt 1", "teardown", "backoff", "attempt 2"]
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mid_operation_closes_window_without_unknown() -> None:
+    """A bare CancelledError mid-operation closes the window and re-raises.
+
+    CancelledError is a BaseException, so the generic ``except Exception`` never
+    sees it; without the dedicated arm the operation window would leak open and
+    the transitional freeze on display, with no poll able to replace it. A cancel is not
+    evidence the lock did or did not move, so, unlike the non-retryable
+    OperationIncompleteError path, NO UNKNOWN is stamped; the transitional
+    stays until the next poll settles it.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    emissions: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: emissions.append(ls.lock))
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens window, stamps LOCKING
+        raise asyncio.CancelledError
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._operation_window_open is False
+    # No UNKNOWN stamp; the transitional persists until a poll's reading replaces it.
+    assert LockStatus.UNKNOWN not in emissions
+    assert push_lock.lock_status == LockStatus.LOCKING
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mid_operation_displays_a_jam_it_received() -> None:
+    """A cancel applies a jam the window filtered out, as every other exit does.
+
+    A cancel is not evidence the lock did or did not move, which is why the test
+    above pins that no status of the operation's own is stamped. A jam is
+    evidence, and this exit is the only chance to apply it: the post-jam
+    register fabricates a plain position, so the status poll this exit schedules puts
+    that on display instead, and no later signal marks the jam.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:4f")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        push_lock._update_any_state([LockStatus.JAMMED])
+        assert push_lock.lock_status == LockStatus.LOCKING  # dropped mid-window
+        raise asyncio.CancelledError
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.JAMMED
+    assert push_lock._operation_window_open is False
+    assert push_lock._seen_intervention_status is None  # cleared when the window closed
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_operation_outside_the_gate_cannot_open_the_window():
+    """A force_* issued straight at the Lock leaves the operation window shut.
+
+    Only _execute_lock_operation hands over the write-success hook, and only
+    that method closes the window again. A caller reaching the Lock directly
+    therefore gets no hook and cannot leave a window open with no operation in
+    flight, which would freeze status admission for the object's life.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:52")
+    push_lock._ble_device = MagicMock()
+    lock = push_lock._get_lock_instance()
+    lock.session = MagicMock()
+    lock.secure_session = MagicMock()
+    lock.client = MagicMock(is_connected=True)
+
+    handed: list[object] = []
+
+    async def _capture(
+        command: bytearray,
+        command_name: str,
+        response_timeout: float = 0.0,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> None:
+        handed.append(write_success_callback)
+        if write_success_callback is not None:
+            write_success_callback()
+
+    lock._execute_operation_command = _capture  # type: ignore[method-assign]
+
+    await lock.force_lock()
+
+    assert handed == [None]
+    assert push_lock._operation_window_open is False
+
+
+@pytest.mark.asyncio
+async def test_execute_lock_operation_hands_the_hook_to_the_operation():
+    """The gated path passes its own write-success hook to the operation."""
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:53")
+    received: list[object] = []
+
+    async def force_lock(write_success_callback):
+        received.append(write_success_callback)
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    assert received == [push_lock._operation_write_success]
+
+
+def _answering_lock(push_lock: PushLock) -> MagicMock:
+    """A mock Lock that answers every member an on-demand update cycle asks for.
+
+    Each read answers the way the real one does: the session hands the frame to
+    the state path before it resolves the waiter the read is blocked on, so the
+    reading is applied through _update_any_state and the returned value carries
+    nothing the state does not already hold.
+    """
+    mock_lock = MagicMock()
+
+    async def lock_status() -> LockStatus:
+        push_lock._update_any_state([LockStatus.LOCKED])
+        return LockStatus.LOCKED
+
+    async def door_status() -> DoorStatus:
+        push_lock._update_any_state([DoorStatus.CLOSED])
+        return DoorStatus.CLOSED
+
+    async def battery() -> BatteryState:
+        reading = BatteryState(voltage=6.0, percentage=80)
+        push_lock._update_any_state([reading])
+        return reading
+
+    mock_lock.lock_status = AsyncMock(side_effect=lock_status)
+    mock_lock.door_status = AsyncMock(side_effect=door_status)
+    mock_lock.battery = AsyncMock(side_effect=battery)
+    return mock_lock
+
+
+@pytest.mark.asyncio
+async def test_failed_operation_leaves_the_status_poll_armed() -> None:
+    """A failed operation must not count as having polled the lock status.
+
+    The join the suite was missing: the UNKNOWN _execute_lock_operation stamps
+    on a non-retryable failure, and the poll gate in _update that reads
+    _seen_this_session, exercised in one test with nothing seeded by hand. In
+    on-demand mode nothing reconnects after this error, so a suppressed poll
+    would leave UNKNOWN on display until the idle disconnect.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:40")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    mock_lock = _answering_lock(push_lock)
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        raise OperationIncompleteError("no op-response")
+
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(
+            push_lock, "_read_auto_lock_setting", AsyncMock(return_value=False)
+        ),
+        patch.object(push_lock, "_schedule_future_update"),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+    assert LockStatus not in push_lock._seen_this_session
+
+    # The following cycle asks the lock for its status, and its reading replaces
+    # the UNKNOWN.
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(
+            push_lock, "_read_auto_lock_setting", AsyncMock(return_value=False)
+        ),
+    ):
+        await push_lock._update()
+
+    mock_lock.lock_status.assert_awaited_once()
+    # Read through _lock_state rather than the lock_status property: an
+    # earlier assert in this test narrows that property to the status it
+    # held before the cycle, which would make everything below unreachable.
+    final_state = push_lock._lock_state
+    assert final_state is not None
+    assert final_state.lock == LockStatus.LOCKED
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_operation_leaves_the_status_poll_armed() -> None:
+    """Cancellation mid-operation leaves the transitional on display, and the
+    following cycle polls it away.
+
+    The CancelledError handler closes the window so acceptance resumes; this
+    pins the other half of that claim, that a later poll's reading replaces it.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:41")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    mock_lock = _answering_lock(push_lock)
+    gate = asyncio.Event()
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        await gate.wait()
+
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(
+            push_lock, "_read_auto_lock_setting", AsyncMock(return_value=False)
+        ),
+        patch.object(push_lock, "_schedule_future_update"),
+    ):
+        op = asyncio.create_task(push_lock.lock())
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if push_lock.lock_status == LockStatus.LOCKING:
+                break
+        op.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await op
+
+        assert push_lock.lock_status == LockStatus.LOCKING
+        assert push_lock._operation_window_open is False
+        assert LockStatus not in push_lock._seen_this_session
+
+        await push_lock._update()
+
+    mock_lock.lock_status.assert_awaited_once()
+    # Read through _lock_state rather than the lock_status property: an
+    # earlier assert in this test narrows that property to the status it
+    # held before the cycle, which would make everything below unreachable.
+    final_state = push_lock._lock_state
+    assert final_state is not None
+    assert final_state.lock == LockStatus.LOCKED
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_reading_leaves_the_status_poll_owed() -> None:
+    """A reading the window refuses does not stand in for a published status.
+
+    _seen_this_session suppresses the follow-up status poll for a value the
+    cycle already carries. Nothing published the refused reading, so keeping
+    the mark would answer the poll obligation with a status no consumer saw.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:6c")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._pending_op_state = LockStatus.UNLOCKING
+    push_lock._operation_write_success()  # opens the window
+
+    push_lock._update_any_state([LockStatus.UNLOCKED])
+
+    assert push_lock.lock_status is LockStatus.UNLOCKING  # the reading was refused
+    assert LockStatus not in push_lock._seen_this_session
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_after_write_success_stamp_unknown() -> None:
+    """Every attempt's write reaches the lock, and every attempt then fails.
+
+    Through the retries the transitional stays on display because the next
+    attempt re-stamps it. Once the attempts run out there is no next attempt,
+    so the operation applies UNKNOWN to the display rather than leaving a
+    transitional standing with no result coming.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:42")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    emissions: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: emissions.append(ls.lock))
+    calls = 0
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        nonlocal calls
+        calls += 1
+        write_success_callback()  # opens the window, stamps LOCKING
+        raise DisconnectedError("dropped after the write, before the ack")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_async_handle_disconnected", AsyncMock()),
+        patch.object(push_lock, "_schedule_future_update"),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(DisconnectedError),
+    ):
+        await push_lock.lock()
+
+    assert calls == DEFAULT_ATTEMPTS
+    # One transitional across all the attempts, then UNKNOWN when they run out.
+    assert emissions == [LockStatus.LOCKING, LockStatus.UNKNOWN]
+    assert push_lock._operation_window_open is False
+    # UNKNOWN is not a reading, so the follow-up poll stays armed.
+    assert LockStatus not in push_lock._seen_this_session
+    # The attempts ran out with no result, so this exit schedules the poll itself.
+    assert push_lock._force_lock_status_poll is True
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_no_update_cycle_is_armed_inside_an_operation() -> None:
+    """Nothing the operation applies arms a cycle while the operation runs.
+
+    A cycle armed here waits on the operation lock and runs the instant the
+    operation ends, inside the post-operation debounce delay the stale-state
+    guard exists to protect. The transitional and the completed status are
+    applied by the operation itself, so they arm nothing; the status poll is
+    scheduled once the operation is over.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:43")
+    # A known prior status, so a change to the transitional would arm a resync.
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    armed_during: list[float] = []
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        if push_lock._cancel_deferred_update is not None:
+            armed_during.append(
+                push_lock._cancel_deferred_update.when() - push_lock.loop.time()
+            )
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    assert armed_during == []
+    assert push_lock._update_task is None
+    assert push_lock.lock_status == LockStatus.LOCKED
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_the_operation_cancels_the_pending_update_on_the_way_in() -> None:
+    """A deferred update armed before the operation is gone once it starts.
+
+    _run_lock_operation cancels the pending update on the way in, before
+    anything awaits, so a cycle scheduled before the command cannot fire while
+    the operation is connecting and poll the lock mid-command. The probe runs
+    inside _ensure_connected, the operation's first await, so only the entry
+    cancel can have cleared the pending cycle by then.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:63")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._schedule_future_update(30.0)
+    assert push_lock._cancel_deferred_update is not None
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(return_value=True)
+    pending_at_connect: list[bool] = []
+
+    async def connected() -> MagicMock:
+        pending_at_connect.append(push_lock._cancel_deferred_update is not None)
+        return mock_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(side_effect=connected)),
+        patch.object(push_lock, "_schedule_future_update"),
+    ):
+        await push_lock.lock()
+
+    # The pending cycle was already gone when the operation connected.
+    assert pending_at_connect == [False]
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "jam", "delay"),
+    [
+        (None, False, KEEP_ALIVE_TIME),
+        (
+            OperationIncompleteError("no op-response"),
+            False,
+            LOCK_STALE_STATE_DEBOUNCE_DELAY,
+        ),
+        (
+            DisconnectedError("dropped after the jam was reported"),
+            True,
+            KEEP_ALIVE_TIME,
+        ),
+    ],
+    ids=["success", "no-result", "jam-ends-the-ladder"],
+)
+async def test_every_operation_exit_schedules_the_status_poll(
+    error: Exception | None, jam: bool, delay: float
+) -> None:
+    """Every way an operation can end schedules the follow-up status poll.
+
+    Success, a result that never came, and a jam that ends the attempt ladder
+    all leave through the same settle, so all three schedule a poll. The delay
+    follows the status each one leaves on display: a position is polled at the
+    keep-alive interval, the cadence an always-connected lock polls at anyway,
+    and the UNKNOWN of a result that never came is polled at the settle
+    debounce, because only a read can replace it.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:44")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        if jam:
+            push_lock._update_any_state([LockStatus.JAMMED])
+        if error is not None:
+            raise error
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update") as scheduled,
+    ):
+        if error is None:
+            await push_lock.lock()
+        else:
+            # The jam ends the ladder with OperationIncompleteError, whatever
+            # retryable type reached it.
+            with pytest.raises(OperationIncompleteError if jam else type(error)):
+                await push_lock.lock()
+
+    assert push_lock._force_lock_status_poll is True
+    scheduled.assert_called_once_with(delay)
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_the_status_poll_keeps_a_sooner_pending_update() -> None:
+    """The status poll inherits the debounce, so a sooner update is kept.
+
+    _finalize_operation schedules the status poll through the deferred-update
+    debounce. An update already due sooner than the keep-alive interval keeps
+    its slot; an undebounced request would displace it a full interval out.
+    Keeping it costs nothing, because the floor _finalize_operation stamps
+    holds the poll itself back: the sooner cycle falls due, finds the floor, and
+    re-arms for the remainder instead of reading the lock before it has passed.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:64")
+    push_lock._schedule_future_update(1.0)
+    handle = push_lock._cancel_deferred_update
+    assert handle is not None
+
+    push_lock._finalize_operation()
+
+    assert push_lock._force_lock_status_poll is True
+    # The sooner cycle is untouched: same handle, still due within a second.
+    assert push_lock._cancel_deferred_update is handle
+    remaining = handle.when() - push_lock.loop.time()
+    assert 0 < remaining <= 1.0
+
+    # It fires early and reads nothing: the floor re-arms it for its remainder.
+    push_lock._deferred_update()
+
+    assert push_lock._update_task is None
+    rearmed = push_lock._cancel_deferred_update
+    assert rearmed is not None and rearmed is not handle
+    assert (
+        LOCK_STALE_STATE_DEBOUNCE_DELAY - 1.0
+        < rearmed.when() - push_lock.loop.time()
+        <= LOCK_STALE_STATE_DEBOUNCE_DELAY
+    )
+    push_lock._cancel_future_update()
+
+
+@pytest.mark.asyncio
+async def test_a_collapsed_schedule_still_waits_for_the_floor() -> None:
+    """A cycle the debounce shortens cannot poll the lock before the floor.
+
+    An update already due inside the coalescing interval makes the debounce
+    rewrite any request to that interval, so the poll _finalize_operation asks
+    for is not the delay the cycle gets. The floor is what holds the poll: the
+    collapsed request is armed for the remainder of that delay instead
+    of firing 25 ms after the operation, when the lock still reports the
+    pre-operation position.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:65")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._schedule_future_update(0.01)
+
+    push_lock._finalize_operation()
+
+    handle = push_lock._cancel_deferred_update
+    assert handle is not None
+    assert (
+        LOCK_STALE_STATE_DEBOUNCE_DELAY - 0.5
+        < handle.when() - push_lock.loop.time()
+        <= LOCK_STALE_STATE_DEBOUNCE_DELAY
+    )
+    push_lock._cancel_future_update()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_polls_sooner_than_the_keep_alive() -> None:
+    """A cancelled operation schedules its own status poll, and sooner.
+
+    A cancel leaves a transitional on display with no result coming while the
+    link is still up, so this poll is deliberately not the keep-alive one. It
+    is armed at the post-operation debounce delay rather than the resync delay,
+    because the written command is still driving the motor and an immediate read
+    would return the pre-operation position. _finalize_operation stamps the floor
+    at the same
+    moment, so a cancel is held out for the same window a completion is,
+    however the request itself is debounced.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:45")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def force_lock(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens the window, stamps LOCKING
+        raise asyncio.CancelledError
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = force_lock
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update") as scheduled,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._force_lock_status_poll is True
+    scheduled.assert_called_once_with(LOCK_STALE_STATE_DEBOUNCE_DELAY)
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_force_lock_status_poll_reads_past_seen_this_session() -> None:
+    """The scheduled status poll asks the lock with LockStatus in _seen_this_session.
+
+    A status the operation applied, or one the display is holding, adds
+    LockStatus to _seen_this_session in the ordinary way; a cycle that honored
+    that would ask the lock nothing and the display would keep whatever it was
+    holding.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:46")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._seen_this_session.add(LockStatus)
+    push_lock._force_lock_status_poll = True
+    mock_lock = _answering_lock(push_lock)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(
+            push_lock, "_read_auto_lock_setting", AsyncMock(return_value=False)
+        ),
+    ):
+        await push_lock._update()
+
+    mock_lock.lock_status.assert_awaited_once()
+    assert push_lock.lock_status == LockStatus.LOCKED
+    # One-shot: the next cycle honours _seen_this_session again.
+    assert push_lock._force_lock_status_poll is False
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_status_read_leaves_the_poll_obligation_armed() -> None:
+    """A lock_status read that raises leaves the forced poll flag set.
+
+    The flag is one-shot, discharged only by a read that answered. Every
+    attempt of this cycle fails at the read itself, so every retry must ask
+    again, and once the retries run out the obligation must still stand for
+    the next cycle.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:66")
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+    push_lock._seen_this_session.add(LockStatus)
+    push_lock._force_lock_status_poll = True
+    mock_lock = _answering_lock(push_lock)
+    mock_lock.lock_status = AsyncMock(side_effect=DisconnectedError("dropped mid-read"))
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(
+            push_lock, "_read_auto_lock_setting", AsyncMock(return_value=False)
+        ),
+        patch.object(push_lock, "_async_handle_disconnected", AsyncMock()),
+        patch("yalexs_ble.push.asyncio.sleep", AsyncMock()),
+        pytest.raises(DisconnectedError),
+    ):
+        await push_lock._update()
+
+    # Only the flag can be asking here (the type is in _seen_this_session), so each
+    # attempt proves the obligation was still set when it started.
+    assert mock_lock.lock_status.await_count == DEFAULT_ATTEMPTS
+    # The read never answered, so the obligation stands for the next cycle.
+    assert push_lock._force_lock_status_poll is True
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [
+        LockStatus.LOCKING,
+        LockStatus.UNLOCKING,
+        LockStatus.UNLATCHING,
+        LockStatus.UNLATCHED,
+        LockStatus.UNKNOWN,
+    ],
+)
+async def test_a_value_the_lock_is_not_holding_is_not_a_status_reading(
+    status: LockStatus,
+) -> None:
+    """None of these is a position the lock stays in, so none suppresses the
+    poll.
+
+    Recording one in _seen_this_session would suppress the follow-up lock_status()
+    poll in _update, and that poll's reading is what replaces it once the
+    mechanism stops. UNLATCHED is here with the transitionals: the latch is
+    open for its dwell and the lock leaves that state on its own.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:47")
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    push_lock._update_any_state([status], arm_resync=False)
+
+    assert push_lock.lock_status == status
+    assert LockStatus not in push_lock._seen_this_session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "position",
+    [
+        LockStatus.LOCKED,
+        LockStatus.UNLOCKED,
+        LockStatus.SECUREMODE,
+        LockStatus.JAMMED,
+        LockStatus.UNKNOWN_01,
+        LockStatus.UNKNOWN_06,
+    ],
+)
+async def test_a_position_the_lock_holds_counts_as_a_status_reading(
+    position: LockStatus,
+) -> None:
+    """The other side of the same set: each of these does suppress the poll.
+
+    The lock stays in each of these until an operation or a person moves it,
+    calibration and polarity discovery included, so the reading stands and
+    asking again this session would tell us nothing new.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:67")
+    push_lock._lock_state = _known_state(LockStatus.UNKNOWN)
+
+    push_lock._update_any_state([position], arm_resync=False)
+
+    assert push_lock.lock_status == position
+    assert LockStatus in push_lock._seen_this_session

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -2642,6 +2642,7 @@ async def test_a_cycle_that_changed_nothing_still_reports() -> None:
         auth=AuthState(successful=True),
         auto_lock=None,
         auto_lock_prev=None,
+        secure=LockStatus.UNLOCKED,
     )
     push_lock._seen_this_session.add(DoorStatus)
     push_lock._seen_this_session.add(BatteryState)
@@ -2752,8 +2753,15 @@ def _operational_push_lock(address: str = "aa:bb:cc:dd:ee:50") -> PushLock:
     return push_lock
 
 
-def _known_state(lock: LockStatus, door: DoorStatus = DoorStatus.CLOSED) -> LockState:
-    """A settled cycle state, so an operation starts from a known position."""
+def _known_state(
+    lock: LockStatus,
+    door: DoorStatus = DoorStatus.CLOSED,
+    secure: LockStatus = LockStatus.UNLOCKED,
+) -> LockState:
+    """A settled cycle state, so an operation starts from a known position.
+
+    The secure lock defaults to not secured.
+    """
     return LockState(
         lock=lock,
         door=door,
@@ -2761,6 +2769,7 @@ def _known_state(lock: LockStatus, door: DoorStatus = DoorStatus.CLOSED) -> Lock
         auth=None,
         auto_lock=None,
         auto_lock_prev=None,
+        secure=secure,
     )
 
 
@@ -2792,6 +2801,333 @@ async def test_execute_lock_operation_success_stamps_complete_state(
 
     getattr(mock_lock, op_attr).assert_awaited_once()
     assert push_lock.lock_status == complete_state
+
+
+@pytest.mark.asyncio
+async def test_securemode_forges_securing_and_neither_lock_flaps() -> None:
+    """Securing an already-locked lock moves the secure lock and not the main.
+
+    The stamped SECURING never publishes; the projection turns it into the
+    pair. The main lock holds at LOCKED and then settles at SECUREMODE, so
+    it cannot run the phantom locked -> locking -> locked cycle a LOCKING
+    stamp caused, while the secure lock runs its own securing transitional.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:60")
+    emissions: list[tuple[LockStatus, LockStatus]] = []
+    push_lock.register_callback(
+        lambda ls, li, ci: emissions.append((ls.lock, ls.secure))
+    )
+
+    # The lock is already locked when securemode is commanded.
+    push_lock._update_any_state([LockStatus.LOCKED])
+    assert emissions == [(LockStatus.LOCKED, LockStatus.UNLOCKED)]
+
+    async def force_securemode(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()
+        # The previous operation's settled push can still land inside this
+        # window; it is refused outright, so neither channel moves off the
+        # stamped pair.
+        push_lock._state_callback([LockStatus.LOCKED])
+
+    mock_lock = MagicMock()
+    mock_lock.force_securemode = force_securemode
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.securemode()
+
+    # The main lock never shows LOCKING, so it cannot flap, and the secure
+    # lock runs unlocked -> locking -> locked.
+    assert emissions == [
+        (LockStatus.LOCKED, LockStatus.UNLOCKED),
+        (LockStatus.LOCKED, LockStatus.LOCKING),
+        (LockStatus.SECUREMODE, LockStatus.LOCKED),
+    ]
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("start", "operation", "op_attr", "expected"),
+    [
+        (
+            (LockStatus.UNLOCKED, LockStatus.UNLOCKED),
+            "lock",
+            "force_lock",
+            [
+                (LockStatus.LOCKING, LockStatus.UNLOCKED),
+                (LockStatus.LOCKED, LockStatus.UNLOCKED),
+            ],
+        ),
+        (
+            (LockStatus.LOCKED, LockStatus.UNLOCKED),
+            "securemode",
+            "force_securemode",
+            [
+                (LockStatus.LOCKED, LockStatus.LOCKING),
+                (LockStatus.SECUREMODE, LockStatus.LOCKED),
+            ],
+        ),
+        (
+            (LockStatus.UNLOCKED, LockStatus.UNLOCKED),
+            "securemode",
+            "force_securemode",
+            [
+                (LockStatus.LOCKING, LockStatus.LOCKING),
+                (LockStatus.SECUREMODE, LockStatus.LOCKED),
+            ],
+        ),
+        (
+            (LockStatus.SECUREMODE, LockStatus.LOCKED),
+            "securemode",
+            "force_securemode",
+            [
+                (LockStatus.SECUREMODE, LockStatus.LOCKING),
+                (LockStatus.SECUREMODE, LockStatus.LOCKED),
+            ],
+        ),
+        (
+            (LockStatus.LOCKED, LockStatus.UNLOCKED),
+            "unlock",
+            "force_unlock",
+            [
+                (LockStatus.UNLOCKING, LockStatus.UNLOCKED),
+                (LockStatus.UNLOCKED, LockStatus.UNLOCKED),
+            ],
+        ),
+        (
+            (LockStatus.SECUREMODE, LockStatus.LOCKED),
+            "unlock",
+            "force_unlock",
+            [
+                (LockStatus.UNLOCKING, LockStatus.UNLOCKING),
+                (LockStatus.UNLOCKED, LockStatus.UNLOCKED),
+            ],
+        ),
+    ],
+    ids=[
+        "lock_unlocked_to_locked",
+        "securemode_locked_to_secured",
+        "securemode_unlocked_to_secured",
+        "securemode_already_secured_moves_only_secure",
+        "unlock_locked_to_unlocked",
+        "unlock_secured_to_unlocked",
+    ],
+)
+async def test_secure_projection_invariant_table(
+    start: tuple[LockStatus, LockStatus],
+    operation: str,
+    op_attr: str,
+    expected: list[tuple[LockStatus, LockStatus]],
+) -> None:
+    """Every operation publishes its own pair for the two logical locks.
+
+    One reported status feeds both, so this table is the invariant. The main
+    lock keeps its present vocabulary, SECUREMODE as the settled secured
+    position and a transitional only where the position itself has to change, and the
+    secure lock reads secured or not secured with transitionals of its own.
+    Each row drives the real operation and records every published pair.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:61")
+    push_lock._lock_state = _known_state(start[0], secure=start[1])
+    emissions: list[tuple[LockStatus, LockStatus]] = []
+    push_lock.register_callback(
+        lambda ls, li, ci: emissions.append((ls.lock, ls.secure))
+    )
+
+    async def force_operation(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()
+
+    mock_lock = MagicMock()
+    setattr(mock_lock, op_attr, force_operation)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update"),
+    ):
+        await getattr(push_lock, operation)()
+
+    assert emissions == expected
+    # The synthetic SECURING is consumed by the projection: no published
+    # value on either channel ever carries it.
+    assert all(LockStatus.SECURING not in pair for pair in emissions)
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_settled_securemode_push_is_not_a_securing_transitional() -> None:
+    """A SECUREMODE push outside an operation is a settled secured position.
+
+    Only securemode() produces SECURING, so a reported SECUREMODE needs no
+    other discriminator: the pair settles at secured at once.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:63")
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    push_lock._state_callback([LockStatus.SECUREMODE])
+
+    assert push_lock.lock_status is LockStatus.SECUREMODE
+    assert push_lock.secure_status is LockStatus.LOCKED
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_a_stamped_plain_locking_reads_not_secured() -> None:
+    """A plain lock() out of Secured reads the secure lock as not secured.
+
+    Only a reported SECUREMODE proves the lock is secured, so a plain
+    LOCKING drops the secure lock to unlocked whatever it held; the settled
+    SECUREMODE that follows a securing motion re-secures it.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:69")
+    push_lock._lock_state = _known_state(
+        LockStatus.SECUREMODE, secure=LockStatus.LOCKED
+    )
+
+    push_lock._pending_op_state = LockStatus.LOCKING
+    push_lock._operation_write_success()
+
+    assert push_lock.lock_status is LockStatus.LOCKING
+    assert push_lock.secure_status is LockStatus.UNLOCKED
+
+
+@pytest.mark.asyncio
+async def test_the_forged_securing_is_not_a_position_the_lock_holds() -> None:
+    """A stamped SECURING must not suppress the follow-up status poll.
+
+    SECURING is the library's own transitional and the motor is running
+    while it stands, so the reading that replaces it can only come from the
+    poll the operation schedules at its exit. Recording LockStatus as seen
+    this session would suppress that poll's read.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:6a")
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    push_lock._update_any_state([LockStatus.SECURING], arm_resync=False)
+
+    assert push_lock.secure_status is LockStatus.LOCKING
+    assert LockStatus not in push_lock._seen_this_session
+
+
+@pytest.mark.asyncio
+async def test_window_filter_refusal_leaves_the_secure_lock_alone() -> None:
+    """A status refused by the window filter never reaches the projection.
+
+    Part way through an unlock out of Secured the published pair is
+    (UNLOCKING, UNLOCKING). The filter returns None for a refused value, so
+    nothing is projected from it. Projecting it instead would read the
+    settled reading as "the lock is not secured" and drop the secure lock to
+    unlocked while the motor is still running.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:64")
+    push_lock._lock_state = _known_state(
+        LockStatus.SECUREMODE, secure=LockStatus.LOCKED
+    )
+    push_lock._pending_op_state = LockStatus.UNLOCKING
+    push_lock._operation_write_success()
+    assert (push_lock.lock_status, push_lock.secure_status) == (
+        LockStatus.UNLOCKING,
+        LockStatus.UNLOCKING,
+    )
+
+    # The previous operation's settled push arriving inside the window is
+    # refused, so the pair stands.
+    push_lock._update_any_state([LockStatus.UNLOCKED])
+    assert (push_lock.lock_status, push_lock.secure_status) == (
+        LockStatus.UNLOCKING,
+        LockStatus.UNLOCKING,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retried_unlock_keeps_the_secure_transitional() -> None:
+    """A second write-success projects the same UNLOCKING again.
+
+    Every attempt stamps its own transitional at write-success, so one
+    unlock can project UNLOCKING more than once. Taking LOCKED alone as
+    evidence that the lock was secured would make the second stamp answer
+    "not secured" and end the transitional with the motor still running.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:65")
+    push_lock._lock_state = _known_state(
+        LockStatus.SECUREMODE, secure=LockStatus.LOCKED
+    )
+
+    # Attempt 1 writes, then fails retryably: the window closes and the
+    # transitional stays on display with nothing stamped over it.
+    push_lock._pending_op_state = LockStatus.UNLOCKING
+    push_lock._operation_write_success()
+    push_lock._close_operation_window()
+    assert push_lock.secure_status is LockStatus.UNLOCKING
+
+    # Attempt 2 writes and stamps the same pending state.
+    push_lock._pending_op_state = LockStatus.UNLOCKING
+    push_lock._operation_write_success()
+    assert (push_lock.lock_status, push_lock.secure_status) == (
+        LockStatus.UNLOCKING,
+        LockStatus.UNLOCKING,
+    )
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_securemode_after_write_stamps_unknown() -> None:
+    """A securemode that dies after its write settles the pair at UNKNOWN.
+
+    The write reached the lock and no op-response followed, so nothing said
+    where the mechanism stopped. The transitional the write stamped is not a
+    position, and the operation replaces it with the unknown one, which the
+    projection carries to both channels.
+    """
+    exc = OperationIncompleteError("no op-response")
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:66")
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    mock_lock = MagicMock()
+
+    async def force_securemode(write_success_callback: Callable[[], None]) -> None:
+        write_success_callback()  # opens window, publishes (LOCKED, LOCKING)
+        raise exc
+
+    mock_lock.force_securemode = force_securemode
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(type(exc)),
+    ):
+        await push_lock.securemode()
+
+    assert push_lock._operation_window_open is False
+    assert push_lock.lock_status is LockStatus.UNKNOWN
+    assert push_lock.secure_status is LockStatus.UNKNOWN
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("secure", "expected_delay"),
+    [
+        (LockStatus.LOCKING, LOCK_STALE_STATE_DEBOUNCE_DELAY),
+        (LockStatus.UNLOCKED, KEEP_ALIVE_TIME),
+    ],
+    ids=["secure_transitional_polls_at_the_debounce", "settled_pair_keeps_alive"],
+)
+async def test_operation_exit_delay_follows_the_displayed_pair(
+    secure: LockStatus, expected_delay: float
+) -> None:
+    """The exit poll delay reads the pair, not the main lock alone.
+
+    A cancelled securemode out of locked leaves (LOCKED, LOCKING) on
+    display: the main lock holds a position, but the secure transitional is
+    unresolved and only a read can settle it, so the poll runs at the settle
+    debounce rather than waiting a keep-alive interval.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:67")
+    push_lock._lock_state = _known_state(LockStatus.LOCKED, secure=secure)
+
+    with patch.object(push_lock, "_schedule_future_update_with_debounce") as schedule:
+        push_lock._finalize_operation()
+
+    schedule.assert_called_once_with(expected_delay)
 
 
 @pytest.mark.asyncio

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -3655,6 +3655,36 @@ async def test_an_operation_settling_after_the_stop_arms_nothing():
 
 
 @pytest.mark.asyncio
+async def test_a_stop_mid_operation_keeps_the_owed_poll_and_the_floor():
+    """The stopped exit still stamps the owed poll and the stale-state floor.
+
+    Both are facts about the mechanism, so a watcher started again on this
+    instance inherits them: its first cycle waits out the motor and asks the
+    lock for the status the stopped operation never displayed.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
+
+    async def _stop_then_fail(write_success_callback):
+        write_success_callback()
+        push_lock._running = False
+        raise OperationIncompleteError("no op-response, and we were stopped")
+
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(side_effect=_stop_then_fail)
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock._force_lock_status_poll is True
+    assert push_lock._earliest_update_time > time.monotonic()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
 async def test_a_jam_recorded_before_the_stop_reaches_no_later_operation():
     """A stopped operation discharges the jam record instead of leaving it set.
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -54,6 +54,7 @@ from yalexs_ble.session import (
     DisconnectedError,
     OperationIncompleteError,
     ResponseError,
+    UnlatchError,
 )
 
 # Shared battery-supporting lock used across tests. model is NOT in
@@ -3381,26 +3382,67 @@ async def test_early_error_before_write_leaves_no_window_and_stamps_unknown():
 
 
 @pytest.mark.asyncio
-async def test_nonretryable_after_write_stamps_unknown():
-    """A non-retryable failure raised after write-success (a transitional is on
-    display with no result coming) closes the window and stamps UNKNOWN."""
-    exc = OperationIncompleteError("no op-response")
+@pytest.mark.parametrize(
+    ("exc", "op_attr", "operation"),
+    [
+        (OperationIncompleteError("no op-response"), "force_lock", "lock"),
+        (UnlatchError("after write"), "force_unlatch", "unlatch"),
+    ],
+)
+async def test_nonretryable_after_write_stamps_unknown(exc, op_attr, operation):
+    """The two non-retryable types raised after write-success (a transitional
+    is on display with no result coming) close the window and stamp UNKNOWN.
+
+    Each type rides the operation that raises it in production: only
+    force_unlatch raises UnlatchError. The single await is the safety
+    property: both types end the attempt ladder on their first raise, and a
+    re-sent unlatch opens the door again.
+    """
     push_lock = _operational_push_lock()
     push_lock._lock_state = _known_state(LockStatus.UNLOCKED)
 
     mock_lock = MagicMock()
 
-    async def force_lock(write_success_callback):
-        write_success_callback()  # opens window, stamps LOCKING
+    async def force_op(write_success_callback):
+        write_success_callback()  # opens the window, stamps the transitional
         raise exc
 
-    mock_lock.force_lock = force_lock
+    mock_op = AsyncMock(side_effect=force_op)
+    setattr(mock_lock, op_attr, mock_op)
 
     with (
         patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
         pytest.raises(type(exc)),
     ):
-        await push_lock.lock()
+        await getattr(push_lock, operation)()
+
+    assert mock_op.await_count == 1
+    assert push_lock._operation_window_open is False
+    assert push_lock._pending_op_state is None
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_unlatch_error_without_a_window_still_stamps_unknown():
+    """An UnlatchError with no window open leaves the position unknown.
+
+    force_unlatch converts every failure from the write attempt onward, so a
+    write call that raised arrives here with the write-success hook never run
+    and the window never opened. The request PDU may still have left the
+    radio, in which case the latch fired and the door is open, so the position
+    on display is no longer evidence.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+
+    mock_lock = MagicMock()
+    mock_lock.force_unlatch = AsyncMock(side_effect=UnlatchError("errored write"))
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(UnlatchError),
+    ):
+        await push_lock.unlatch()
 
     assert push_lock._operation_window_open is False
     assert push_lock._pending_op_state is None
@@ -4222,7 +4264,9 @@ async def test_operation_outside_the_gate_cannot_open_the_window():
         command: bytearray,
         command_name: str,
         response_timeout: float = 0.0,
+        progress: object | None = None,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> None:
         handed.append(write_success_callback)
         if write_success_callback is not None:
@@ -4450,6 +4494,39 @@ async def test_exhausted_retries_after_write_success_stamp_unknown() -> None:
     assert LockStatus not in push_lock._seen_this_session
     # The attempts ran out with no result, so this exit schedules the poll itself.
     assert push_lock._force_lock_status_poll is True
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_unlatch_stamps_unlatching_then_unlocked():
+    """The new public unlatch() maps to force_unlatch, stamping UNLATCHING at
+    write-success and UNLOCKED on success: the op-response arrives when the
+    latch has returned from its open dwell, so UNLATCHED is never the
+    completed state."""
+    push_lock = _operational_push_lock()
+    order: list[str | LockStatus] = []
+
+    def cb(lock_state, lock_info, connection_info):
+        order.append(lock_state.lock)
+
+    push_lock.register_callback(cb)
+
+    mock_lock = MagicMock()
+
+    async def force_unlatch(write_success_callback):
+        order.append("write_success")
+        write_success_callback()
+
+    mock_lock.force_unlatch = force_unlatch
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.unlatch()
+
+    assert order == ["write_success", LockStatus.UNLATCHING, LockStatus.UNLOCKED]
+    assert push_lock.lock_status == LockStatus.UNLOCKED
+    push_lock._cancel_future_update()
     push_lock._cancel_disconnect_timer()
 
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -3267,6 +3267,29 @@ async def test_write_success_without_pending_state_stamps_nothing():
 
 
 @pytest.mark.asyncio
+async def test_a_raising_stamp_still_opens_the_window():
+    """The window opens even when stamping the transitional raises.
+
+    The session contains an exception from the write-success hook and runs
+    the staged wait to its end, so a raise that left the window closed would
+    run the whole operation with every mid-motion status admitted and no
+    intervention status recorded.
+    """
+    push_lock = _operational_push_lock()
+    push_lock._pending_op_state = LockStatus.LOCKING
+
+    with (
+        patch.object(
+            push_lock, "_update_any_state", side_effect=RuntimeError("stamp failed")
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        push_lock._operation_write_success()
+
+    assert push_lock._operation_window_open is True
+
+
+@pytest.mark.asyncio
 async def test_window_filters_foreign_settle_until_close():
     """While the operation window is open a foreign lock-status settle is
     dropped; once the window closes the same value is admitted."""

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -4519,16 +4519,19 @@ async def test_unlatch_stamps_unlatching_then_unlatched():
 
     mock_lock.force_unlatch = force_unlatch
 
-    with patch.object(
-        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        patch.object(push_lock, "_schedule_future_update_with_debounce") as schedule,
     ):
         await push_lock.unlatch()
 
     assert order == ["write_success", LockStatus.UNLATCHING, LockStatus.UNLATCHED]
     assert push_lock.lock_status == LockStatus.UNLATCHED
-    # UNLATCHED is not a position, so it is not marked seen and the cycles
-    # after the follow-up poll keep asking for the settled reading.
-    assert LockStatus not in push_lock._seen_this_session
+    # UNLATCHED is a position the lock holds, so it is marked seen as any
+    # other position is, and the follow-up poll the operation owes waits
+    # the keep-alive.
+    assert LockStatus in push_lock._seen_this_session
+    schedule.assert_called_once_with(KEEP_ALIVE_TIME)
     push_lock._cancel_future_update()
     push_lock._cancel_disconnect_timer()
 
@@ -4906,7 +4909,6 @@ async def test_a_failed_status_read_leaves_the_poll_obligation_armed() -> None:
         LockStatus.LOCKING,
         LockStatus.UNLOCKING,
         LockStatus.UNLATCHING,
-        LockStatus.UNLATCHED,
         LockStatus.UNKNOWN,
     ],
 )
@@ -4918,8 +4920,7 @@ async def test_a_value_the_lock_is_not_holding_is_not_a_status_reading(
 
     Recording one in _seen_this_session would suppress the follow-up lock_status()
     poll in _update, and that poll's reading is what replaces it once the
-    mechanism stops. UNLATCHED is here with the transitionals: the latch is
-    open for its dwell and the lock leaves that state on its own.
+    mechanism stops.
     """
     push_lock = _operational_push_lock("aa:bb:cc:dd:ee:47")
     push_lock._lock_state = _known_state(LockStatus.LOCKED)
@@ -4936,6 +4937,7 @@ async def test_a_value_the_lock_is_not_holding_is_not_a_status_reading(
     [
         LockStatus.LOCKED,
         LockStatus.UNLOCKED,
+        LockStatus.UNLATCHED,
         LockStatus.SECUREMODE,
         LockStatus.JAMMED,
         LockStatus.UNKNOWN_01,
@@ -4947,9 +4949,9 @@ async def test_a_position_the_lock_holds_counts_as_a_status_reading(
 ) -> None:
     """The other side of the same set: each of these does suppress the poll.
 
-    The lock stays in each of these until an operation or a person moves it,
-    calibration and polarity discovery included, so the reading stands and
-    asking again this session would tell us nothing new.
+    The lock stays in each of these until an operation, a person, or its own
+    timer moves it, calibration and polarity discovery included, so the
+    reading stands until the lock reports the next one.
     """
     push_lock = _operational_push_lock("aa:bb:cc:dd:ee:67")
     push_lock._lock_state = _known_state(LockStatus.UNKNOWN)

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -3014,29 +3014,27 @@ async def test_the_forged_securing_is_not_a_position_the_lock_holds() -> None:
 async def test_window_filter_refusal_leaves_the_secure_lock_alone() -> None:
     """A status refused by the window filter never reaches the projection.
 
-    Part way through an unlock out of Secured the published pair is
-    (UNLOCKING, UNLOCKING). The filter returns None for a refused value, so
-    nothing is projected from it. Projecting it instead would read the
-    settled reading as "the lock is not secured" and drop the secure lock to
-    unlocked while the motor is still running.
+    Part way through a securemode out of locked the published pair is
+    (LOCKED, LOCKING). The filter returns None for a refused value, so
+    nothing is projected from it. Re-projecting the standing display instead
+    would read the settled main lock as "the lock is not secured" and end
+    the secure transitional while the motor is still running.
     """
     push_lock = _operational_push_lock("aa:bb:cc:dd:ee:64")
-    push_lock._lock_state = _known_state(
-        LockStatus.SECUREMODE, secure=LockStatus.LOCKED
-    )
-    push_lock._pending_op_state = LockStatus.UNLOCKING
+    push_lock._lock_state = _known_state(LockStatus.LOCKED)
+    push_lock._pending_op_state = LockStatus.SECURING
     push_lock._operation_write_success()
     assert (push_lock.lock_status, push_lock.secure_status) == (
-        LockStatus.UNLOCKING,
-        LockStatus.UNLOCKING,
+        LockStatus.LOCKED,
+        LockStatus.LOCKING,
     )
 
     # The previous operation's settled push arriving inside the window is
     # refused, so the pair stands.
-    push_lock._update_any_state([LockStatus.UNLOCKED])
+    push_lock._update_any_state([LockStatus.LOCKED])
     assert (push_lock.lock_status, push_lock.secure_status) == (
-        LockStatus.UNLOCKING,
-        LockStatus.UNLOCKING,
+        LockStatus.LOCKED,
+        LockStatus.LOCKING,
     )
 
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -3888,8 +3888,8 @@ async def test_jam_inside_the_window_ends_the_attempt_ladder() -> None:
 async def test_a_new_commands_write_success_clears_the_jam_record() -> None:
     """A command that reaches the lock supersedes a jam still on record.
 
-    Every operation exit applies a status it recorded, so no exit leaves
-    _seen_intervention_status set for the next command to find. The record is
+    No exit leaves _seen_intervention_status set for the next command to
+    find: _close_operation_window clears it above the stop check. The record is
     seeded by hand here to pin the backstop: were one ever to reach a
     write-success, the command the caller issued after the jam is the
     intervention that status calls for, and its own result is what the display

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -4498,11 +4498,11 @@ async def test_exhausted_retries_after_write_success_stamp_unknown() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unlatch_stamps_unlatching_then_unlocked():
-    """The new public unlatch() maps to force_unlatch, stamping UNLATCHING at
-    write-success and UNLOCKED on success: the op-response arrives when the
-    latch has returned from its open dwell, so UNLATCHED is never the
-    completed state."""
+async def test_unlatch_stamps_unlatching_then_unlatched():
+    """The public unlatch() maps to force_unlatch, stamping UNLATCHING at
+    write-success and UNLATCHED on success: the op-response answers the
+    latch pull, so the operation's own outcome is the open door lock, and
+    the state the lock settles to arrives as a later status update."""
     push_lock = _operational_push_lock()
     order: list[str | LockStatus] = []
 
@@ -4524,8 +4524,81 @@ async def test_unlatch_stamps_unlatching_then_unlocked():
     ):
         await push_lock.unlatch()
 
-    assert order == ["write_success", LockStatus.UNLATCHING, LockStatus.UNLOCKED]
-    assert push_lock.lock_status == LockStatus.UNLOCKED
+    assert order == ["write_success", LockStatus.UNLATCHING, LockStatus.UNLATCHED]
+    assert push_lock.lock_status == LockStatus.UNLATCHED
+    # UNLATCHED is not a position, so it is not marked seen and the cycles
+    # after the follow-up poll keep asking for the settled reading.
+    assert LockStatus not in push_lock._seen_this_session
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resting_state",
+    [LockStatus.UNLOCKED, LockStatus.LOCKED],
+    ids=["unlocked", "locked"],
+)
+async def test_the_resting_state_replaces_unlatched_when_it_arrives(
+    resting_state: LockStatus,
+) -> None:
+    """A status arriving after the unlatch completes replaces UNLATCHED.
+
+    The lock reports UNLATCHED for the whole dwell and settles where the
+    mechanism takes it: UNLOCKED, or LOCKED once auto-relock has run or on
+    a lock with no separate unlocked rest. The display follows the report
+    either way.
+    """
+    push_lock = _operational_push_lock()
+    mock_lock = MagicMock()
+
+    async def force_unlatch(write_success_callback):
+        write_success_callback()
+
+    mock_lock.force_unlatch = force_unlatch
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.unlatch()
+
+    assert push_lock.lock_status == LockStatus.UNLATCHED
+    push_lock._state_callback([resting_state])
+    assert push_lock.lock_status == resting_state
+    push_lock._cancel_future_update()
+    push_lock._cancel_disconnect_timer()
+
+
+@pytest.mark.asyncio
+async def test_unlatching_a_secured_lock_animates_then_releases_the_secure_lock() -> (
+    None
+):
+    """An unlatch is the Unlock opcode, so it releases a secured lock.
+
+    The secure channel animates UNLOCKING while the latch is driven and
+    reads UNLOCKED once the operation completes: UNLATCHED is the main
+    lock's value alone and never reaches the secure channel.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:51")
+    push_lock._lock_state = _known_state(
+        LockStatus.SECUREMODE, secure=LockStatus.LOCKED
+    )
+    secure: list[LockStatus] = []
+    push_lock.register_callback(lambda ls, li, ci: secure.append(ls.secure))
+    mock_lock = MagicMock()
+
+    async def force_unlatch(write_success_callback):
+        write_success_callback()
+
+    mock_lock.force_unlatch = force_unlatch
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.unlatch()
+
+    assert secure == [LockStatus.UNLOCKING, LockStatus.UNLOCKED]
+    assert push_lock.lock_status == LockStatus.UNLATCHED
     push_lock._cancel_future_update()
     push_lock._cancel_disconnect_timer()
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -33,8 +33,10 @@ from yalexs_ble.push import (
     AUTO_LOCK_WRITE_ATTEMPTS,
     BATTERY_REFRESH_INTERVAL,
     BATTERY_TIMEOUT_COOLDOWN,
+    DEADLINE_WAKEUP_RETRY_DELAY,
     DEFAULT_ATTEMPTS,
     HAP_FIRST_BYTE,
+    LOCK_STALE_STATE_DEBOUNCE_DELAY,
     NEVER_TIME,
     NO_BATTERY_SUPPORT_MODELS,
     SLOW_LATENCY,
@@ -46,7 +48,11 @@ from yalexs_ble.push import (
     operation_lock,
     retry_bluetooth_connection_error,
 )
-from yalexs_ble.session import DisconnectedError, ResponseError
+from yalexs_ble.session import (
+    DisconnectedError,
+    OperationIncompleteError,
+    ResponseError,
+)
 
 # Shared battery-supporting lock used across tests. model is NOT in
 # NO_BATTERY_SUPPORT_MODELS, so the battery-workaround path is not taken.
@@ -2728,3 +2734,99 @@ async def test_every_read_a_cycle_issues_records_the_round_trip_as_a_success(
 
     assert push_lock.auth == AuthState(successful=True)
     assert _AUTH_FAILURE_HISTORY.should_raise(address) is False
+
+
+# ---------------------------------------------------------------------------
+# Lock operations completed by their own op-response
+# ---------------------------------------------------------------------------
+
+
+def _operational_push_lock(address: str = "aa:bb:cc:dd:ee:50") -> PushLock:
+    """A running lock with lock_info and advertisement data, ready to operate."""
+    push_lock = _named_push_lock(address, always_connected=False)
+    push_lock._lock_info = TEST_LOCK_INFO
+    push_lock._running = True
+    push_lock._advertisement_data = _advertisement({})
+    return push_lock
+
+
+@pytest.mark.asyncio
+async def test_execute_lock_operation_success_stamps_complete_state() -> None:
+    """A completed force_* advances the state to the completed status.
+
+    Drives lock() to completion: the transitional LOCKING is stamped, the
+    operation returns, and the completed LOCKED status is applied.
+    """
+    push_lock = _operational_push_lock()
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock()
+
+    with patch.object(
+        push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)
+    ):
+        await push_lock.lock()
+
+    mock_lock.force_lock.assert_awaited_once()
+    assert push_lock.lock_status == LockStatus.LOCKED
+
+
+@pytest.mark.asyncio
+async def test_failed_operation_anchors_the_stale_state_debounce() -> None:
+    """A failed force_* holds the next cycle off as a completed one does.
+
+    The command reached the lock, so the motor may have run and the position
+    is unknown rather than unchanged. The failed attempt stamps the anchor a
+    completed one stamps, and a cycle falling due inside the debounce that
+    follows is rescheduled rather than run.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:39")
+    mock_lock = MagicMock()
+    mock_lock.force_lock = AsyncMock(
+        side_effect=OperationIncompleteError("no op-response")
+    )
+
+    with (
+        patch.object(push_lock, "_ensure_connected", AsyncMock(return_value=mock_lock)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await push_lock.lock()
+
+    assert push_lock.lock_status == LockStatus.UNKNOWN
+
+    with patch.object(
+        push_lock, "_schedule_future_update_with_debounce"
+    ) as mock_reschedule:
+        push_lock._deferred_update()
+
+    assert push_lock._update_task is None
+    (delay,) = mock_reschedule.call_args.args
+    assert delay < LOCK_STALE_STATE_DEBOUNCE_DELAY
+
+
+@pytest.mark.asyncio
+async def test_deferred_update_backs_off_while_an_operation_holds_the_lock() -> None:
+    """A cycle falling due mid-operation backs off rather than queueing.
+
+    The stale-state debounce is measured from the last operation to have
+    finished, so an operation still running passes it. Creating the cycle
+    there would put it behind the operation lock, and it would read the lock
+    the moment the operation released it, inside the window the debounce
+    exists to keep it out of.
+    """
+    push_lock = _operational_push_lock("aa:bb:cc:dd:ee:38")
+    # The previous operation's anchor is old enough that the debounce passes.
+    push_lock._last_lock_operation_complete_time = (
+        time.monotonic() - LOCK_STALE_STATE_DEBOUNCE_DELAY - 1
+    )
+
+    await push_lock._operation_lock.acquire()
+    try:
+        with patch.object(
+            push_lock, "_schedule_future_update_with_debounce"
+        ) as mock_reschedule:
+            push_lock._deferred_update()
+    finally:
+        push_lock._operation_lock.release()
+
+    assert push_lock._update_task is None
+    mock_reschedule.assert_called_once_with(DEADLINE_WAKEUP_RETRY_DELAY)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -24,6 +24,7 @@ from yalexs_ble.session import (
     COOLDOWN_TIME,
     OPERATION_RESPONSE_TIMEOUT,
     RESPONSE_FRAME_LEN,
+    UNLATCH_OPERATION_RESPONSE_TIMEOUT,
     AuthError,
     DisconnectedError,
     OperationIncompleteError,
@@ -1030,6 +1031,93 @@ async def test_execute_operation_ack_timeout(
     assert progress.acknowledged is False
 
 
+@pytest.mark.asyncio
+async def test_the_no_ack_wait_completes_on_the_op_response_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """wait_for_ack=False waits for the op-response alone, for the whole budget.
+
+    The lock acknowledges nothing here and its op-response lands past the
+    acknowledgment budget but well inside the operation's own. With the
+    acknowledgment stage the attempt ends as a TimeoutError before that
+    result can arrive; without it the same exchange completes on the result
+    the lock sent.
+    """
+    monkeypatch.setattr("yalexs_ble.session.ACK_TIMEOUT", 0.05)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def run(wait_for_ack: bool) -> bytes:
+        session, client = _make_operation_session()
+        progress = OperationProgress()
+
+        async def feed() -> None:
+            await _spin_until_written(client)
+            await asyncio.sleep(0.12)
+            session._notify(0, bytearray(op_response))
+
+        feeder = asyncio.create_task(feed())
+        try:
+            return await session.execute_operation(
+                session.build_operation_command(Commands.LOCK, 0x04),
+                "force_securemode",
+                ack_matcher=_ack_matcher(0x0B, 0x04),
+                response_matcher=_operation_response_matcher(0x0B),
+                response_timeout=5.0,
+                progress=progress,
+                wait_for_ack=wait_for_ack,
+            )
+        finally:
+            feeder.cancel()
+
+    assert await run(wait_for_ack=False) == bytes(op_response)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await run(wait_for_ack=True)
+    # The acknowledgment stage, not the op-response budget: a plain
+    # TimeoutError, so the caller that allows a re-send still gets one.
+    assert not isinstance(exc_info.value, OperationIncompleteError)
+
+
+@pytest.mark.asyncio
+async def test_the_no_ack_timeout_reports_the_missing_acknowledgment() -> None:
+    """The stage-2 timeout message says when the command was never acknowledged.
+
+    With the acknowledgment stage skipped, the message suffix is the one
+    trace of whether the lock answered at all: it separates a link that
+    never delivered the command from a motor that ran long. No frames at
+    all appends it; an acknowledgment that did arrive removes it.
+    """
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def run(deliver_ack: bool) -> str:
+        session, client = _make_operation_session()
+        progress = OperationProgress()
+
+        async def feed() -> None:
+            await _spin_until_written(client)
+            session._notify(0, bytearray(ack))
+
+        feeder = asyncio.create_task(feed()) if deliver_ack else None
+        try:
+            with pytest.raises(OperationIncompleteError) as exc_info:
+                await session.execute_operation(
+                    session.build_operation_command(Commands.LOCK, 0x04),
+                    "force_securemode",
+                    ack_matcher=_ack_matcher(0x0B, 0x04),
+                    response_matcher=_operation_response_matcher(0x0B),
+                    response_timeout=0.2,
+                    progress=progress,
+                    wait_for_ack=False,
+                )
+        finally:
+            if feeder is not None:
+                feeder.cancel()
+        return str(exc_info.value)
+
+    assert "never acknowledged" in await run(deliver_ack=False)
+    assert "never acknowledged" not in await run(deliver_ack=True)
+
+
 def test_ack_timeout_outlasts_the_link_supervision_timeout() -> None:
     """Stage 1 must outlast a dead link, so a dead link reads as a disconnect.
 
@@ -1041,17 +1129,26 @@ def test_ack_timeout_outlasts_the_link_supervision_timeout() -> None:
     assert ACK_TIMEOUT > SLOW_TIMEOUT / 100
 
 
-def test_operation_response_timeout_outlasts_the_acknowledgment_budget() -> None:
-    """Stage 2's budget must exceed stage 1's.
+@pytest.mark.parametrize(
+    "budget",
+    [OPERATION_RESPONSE_TIMEOUT, UNLATCH_OPERATION_RESPONSE_TIMEOUT],
+    ids=["plain", "unlatch"],
+)
+def test_operation_response_timeout_outlasts_the_acknowledgment_budget(
+    budget: float,
+) -> None:
+    """Every op-response budget must exceed the acknowledgment budget.
 
     Both stage deadlines run from the command issue, so everything the
     acknowledgment stage consumes comes out of the op-response budget; a
     budget at or below ACK_TIMEOUT could reach stage 2 with nothing left and
-    fail the operation the moment the acknowledgment lands. The relationship
-    is the invariant; the value itself is sized off the observed op-response
-    arrival distribution and moves with it.
+    fail the operation the moment the acknowledgment lands. The unlatch
+    skips the acknowledgment stage, but ACK_TIMEOUT still bounds its GATT
+    write, so the same floor holds. The relationship is the invariant; the
+    plain budget is sized off the observed op-response arrival distribution
+    and moves with it, and the unlatch budget derives from its latch travel.
     """
-    assert OPERATION_RESPONSE_TIMEOUT > ACK_TIMEOUT
+    assert budget > ACK_TIMEOUT
 
 
 def test_operation_incomplete_error_passes_the_retry_decorator() -> None:
@@ -1644,6 +1741,7 @@ async def test_bleak_disconnect_after_ack_is_operation_incomplete() -> None:
         response_timeout: float,
         progress: OperationProgress,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> bytes:
         progress.acknowledged = True
         raise BleakError("device disconnected")
@@ -1677,6 +1775,7 @@ async def test_bleak_disconnect_in_one_turn_with_the_op_response_returns_it() ->
         response_timeout: float,
         progress: OperationProgress,
         write_success_callback: Callable[[], None] | None = None,
+        wait_for_ack: bool = True,
     ) -> bytes:
         progress.acknowledged = True
         progress.result = op_response

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -963,6 +963,42 @@ async def test_execute_operation_op_response_before_ack() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
+    """A previous same-opcode command's late op-response is taken as the answer.
+
+    An op-response is matched on the opcode alone, so a fresh wait cannot
+    tell its own answer from the previous same-opcode command's late one:
+    fed during stage 1, the stale frame completes the wait through the
+    supersede branch. progress.acknowledged staying False is the tell that
+    the result may not be this command's.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    # The same bytes a previous lock-opcode command's op-response carries.
+    stale_op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # Arrives before this command's acknowledgment.
+        session._notify(0, bytearray(stale_op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(stale_op_response)
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
 async def test_execute_operation_ack_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,8 @@
-"""Session-level tests for frame admission and the solicited-response matcher."""
+"""Session-level tests for frame admission, the response matcher and the staged wait."""
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,9 +12,25 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from yalexs_ble import util
 from yalexs_ble.const import Commands, SettingType
-from yalexs_ble.lock import _settings_response_matcher
+from yalexs_ble.lock import (
+    _ack_matcher,
+    _operation_response_matcher,
+    _settings_response_matcher,
+)
+from yalexs_ble.push import RETRYABLE_EXCEPTIONS, SLOW_TIMEOUT
 from yalexs_ble.secure_session import SecureSession
-from yalexs_ble.session import RESPONSE_FRAME_LEN, ResponseError, Session
+from yalexs_ble.session import (
+    ACK_TIMEOUT,
+    COOLDOWN_TIME,
+    OPERATION_RESPONSE_TIMEOUT,
+    RESPONSE_FRAME_LEN,
+    AuthError,
+    DisconnectedError,
+    OperationIncompleteError,
+    OperationProgress,
+    ResponseError,
+    Session,
+)
 
 # Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
 # acknowledgment and, ~40 ms later, the 0xBB frame carrying the stored value
@@ -121,7 +138,9 @@ async def test_corrupt_frame_disarms_the_wait_and_the_command_is_retried() -> No
 
     The corrupt frame resolves the future with a ResponseError, so the matcher
     must be cleared with it -- otherwise the retry re-arms the wait with the
-    previous command's matcher still in place.
+    previous command's matcher still in place. The staged operation wait skips
+    corrupt frames instead; this is the plain path, where re-writing a settings
+    command costs nothing.
     """
     received: list[bytes] = []
     session = _make_session(received)
@@ -540,3 +559,1271 @@ async def test_a_secure_session_handshake_frame_still_answers_its_wait() -> None
     assert len(on_air) == RESPONSE_FRAME_LEN
     result = await session.execute(session.build_command(0x01), "KEY_EXCHANGE")
     assert result == bytes(answer)
+
+
+def _with_checksum(hex_str: str) -> bytearray:
+    """Build an 18-byte frame with a valid simple checksum in byte[3].
+
+    _validate_response requires the 18-byte simple checksum to sum to zero;
+    byte[3] is the checksum field, so set it to whatever makes that hold.
+    """
+    frame = bytearray.fromhex(hex_str)
+    frame[0x03] = 0
+    frame[0x03] = util._simple_checksum(frame)
+    return frame
+
+
+async def _spin_until(predicate: Callable[[], bool]) -> None:
+    """Yield to the event loop until predicate() holds (bounded).
+
+    Lets the operation under test advance to its next awaited stage before the
+    test feeds the next frame, so each _notify lands in the intended stage.
+    """
+    for _ in range(1000):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition was never reached")
+
+
+async def _spin_until_written(client: MagicMock, writes: int = 1) -> None:
+    """Yield until the GATT write has returned.
+
+    The write is where the staged wait begins: both stage futures are armed
+    before it, and the writer reaches its first await straight after it. A
+    frame fed once the write has returned therefore lands in the stage the
+    test intends.
+    """
+    await _spin_until(lambda: client.write_gatt_char.await_count >= writes)
+
+
+def _make_operation_session(
+    state_callback: Callable[[bytes], None] | None = None,
+) -> tuple[Session, MagicMock]:
+    """Build a Session over a mock client for the notify/staged-wait path.
+
+    Only cipher_encrypt is set (execute_operation asserts it); cipher_decrypt
+    is left None so notify frames pass through Session.decrypt unmodified.
+    """
+    client = MagicMock()
+    client.is_connected = True
+    client.write_gatt_char = AsyncMock()
+    session = Session(client, "mylock", asyncio.Lock(), set(), state_callback)
+    session.cipher_encrypt = Cipher(
+        algorithms.AES(bytes(16)),
+        modes.CBC(bytes(16)),
+    ).encryptor()
+    return session, client
+
+
+# securemode = LOCK opcode (0x0B) with operation byte 0x04.
+_ACK_SECUREMODE = "aa0b00000400000000000000000000000200"
+_OP_RESPONSE_OK = "bb0b00000000000000000000000000000200"
+_SETTLED_STATUS = "bb0200000200000000000000000000000200"
+_FOREIGN_ACK = "aa0b00000000000000000000000000000200"
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_happy_path() -> None:
+    """Write, then ack, then op-response: returns the op-response bytes.
+
+    write_success_callback fires once, before the ack is delivered.
+    """
+    order: list[str] = []
+    session, client = _make_operation_session()
+    write_cb = MagicMock(side_effect=lambda: order.append("write"))
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        order.append("ack")
+        session._notify(0, bytearray(ack))
+        # Deliver the op-response in the SAME event-loop turn: both stage
+        # futures resolve before the writer resumes, exercising the
+        # supersede branch, which must still record the acknowledgment.
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+        write_success_callback=write_cb,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert client.write_gatt_char.await_count == 1
+    assert progress.write_attempted is True
+    assert progress.acknowledged is True
+    write_cb.assert_called_once()
+    # The callback fired before the ack was delivered.
+    assert order == ["write", "ack"]
+
+
+@pytest.mark.asyncio
+async def test_a_raising_write_success_callback_does_not_abort_the_staged_wait(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A write_success_callback that raises is contained, and the wait goes on.
+
+    The hook runs after the command is confirmed delivered, so an exception
+    escaping it would abandon a wait whose motor may be running, and the
+    escaped type would be retried upstream and re-send the command. The
+    exception is logged at error level, since a raising hook is a bug in the
+    caller, and the staged wait still completes on its op-response.
+    """
+    session, client = _make_operation_session()
+    write_cb = MagicMock(side_effect=RuntimeError("hook bug"))
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    with caplog.at_level("ERROR", logger="yalexs_ble.session"):
+        result = await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+            write_success_callback=write_cb,
+        )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+    write_cb.assert_called_once()
+    assert "write success callback for force_securemode raised" in caplog.text
+    assert "hook bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_ignores_foreign_frames() -> None:
+    """A settle and a foreign ack mid-wait do not complete the operation."""
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    settled = _with_checksum(_SETTLED_STATUS)
+    foreign_ack = _with_checksum(_FOREIGN_ACK)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # A settled GETSTATUS (0xBB 0x02) and a foreign ack (0xAA 0x0B with
+        # operation byte 0x00, not the securemode 0x04) must not complete it.
+        session._notify(0, bytearray(settled))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(foreign_ack))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+    # The foreign frames were still handed to the state callback.
+    assert bytes(settled) in seen
+    assert bytes(foreign_ack) in seen
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_acknowledgment_is_inert_and_the_operation_completes() -> None:
+    """A second matching acknowledgment resolves nothing and raises nothing.
+
+    The acknowledgment slot is cleared as the first matching frame resolves
+    it, which is what makes the resolution safe without a done() check. Left
+    armed, the duplicate would resolve a future that is already done and raise
+    InvalidStateError inside the notify callback, which the Bluetooth stack
+    calls with nobody to catch it.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    escaped: list[BaseException] = []
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        try:
+            # The same acknowledgment again, now in the op-response stage.
+            session._notify(0, bytearray(ack))
+        except Exception as err:
+            escaped.append(err)
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert escaped == []
+    assert result == bytes(op_response)
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_operation_wait_skips_a_corrupt_frame_and_completes() -> None:
+    """A frame that fails the checksum mid-operation is skipped, not surfaced.
+
+    On the plain path a checksum failure ends the wait so the caller can write
+    the command again. A mechanical command must not be written again on the
+    strength of a bad frame, so the operation wait skips it and keeps waiting
+    for the op-response.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    # The op-response frame with its checksum field broken, so it decodes as
+    # this command's answer but fails validation.
+    corrupt = bytearray(op_response)
+    corrupt[0x03] ^= 0xFF
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(corrupt))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    # The corrupt frame neither answered the command nor ended the wait.
+    assert result == bytes(op_response)
+    assert session.client.write_gatt_char.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_wait_skips_a_corrupt_frame_after_the_acknowledgment() -> None:
+    """A corrupt frame in the op-response stage is skipped too.
+
+    The acknowledgment's own arming is cleared the moment it arrives, so the
+    op-response stage looks exactly like a plain wait; _operation_progress is
+    what still marks it as an operation. Keying the skip on the acknowledgment
+    arming instead would error this wait and re-send a mechanical command the
+    lock has already taken.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+    corrupt = bytearray(op_response)
+    corrupt[0x03] ^= 0xFF
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(corrupt))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert session.client.write_gatt_char.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_progress_is_cleared_so_the_plain_path_still_retries() -> None:
+    """The staged wait clears its progress record on the way out.
+
+    _operation_progress is what tells _notify to skip a corrupt frame rather
+    than error the wait. Left set after an operation, it would disable the
+    plain path's corrupt-frame retry for the life of the connection.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    await session.execute_operation(
+        session.build_operation_command(Commands.LOCK, 0x04),
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert session._operation_progress is None
+
+    # A plain command behind the operation: its corrupt frame must still end
+    # the wait and make _locked_write write the command again.
+    good = _with_checksum(_SETTLED_STATUS)
+    bad = bytearray(good)
+    bad[0x03] ^= 0xFF
+    frames = [bad, good]
+
+    async def deliver(*_args: object, **_kwargs: object) -> None:
+        session._notify(0, bytearray(frames.pop(0)))
+
+    client.write_gatt_char = AsyncMock(side_effect=deliver)
+    result = await session.execute(
+        session.build_command(Commands.GETSTATUS), "lock_status"
+    )
+
+    assert result == bytes(good)
+    assert client.write_gatt_char.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_op_response_before_ack() -> None:
+    """The op-response alone completes the wait; the ack stage is superseded."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    # No acknowledgment was needed to complete.
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_ack_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No acknowledgment within the ack budget raises a plain TimeoutError."""
+    monkeypatch.setattr("yalexs_ble.session.ACK_TIMEOUT", 0.05)
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    # A plain TimeoutError, not the non-retryable OperationIncompleteError:
+    # nothing was acknowledged, so the command may still be retried.
+    assert not isinstance(exc_info.value, OperationIncompleteError)
+    assert client.write_gatt_char.await_count == 1
+    assert progress.acknowledged is False
+
+
+def test_ack_timeout_outlasts_the_link_supervision_timeout() -> None:
+    """Stage 1 must outlast a dead link, so a dead link reads as a disconnect.
+
+    SLOW_TIMEOUT is the slow-mode supervision timeout in BLE units of 10 ms.
+    Below it, a link that has already gone expires this stage instead, and a
+    missing acknowledgment is retryable: the command would be written again
+    to a lock that may have taken it.
+    """
+    assert ACK_TIMEOUT > SLOW_TIMEOUT / 100
+
+
+def test_operation_response_timeout_outlasts_the_acknowledgment_budget() -> None:
+    """Stage 2's budget must exceed stage 1's.
+
+    Both stage deadlines run from the command issue, so everything the
+    acknowledgment stage consumes comes out of the op-response budget; a
+    budget at or below ACK_TIMEOUT could reach stage 2 with nothing left and
+    fail the operation the moment the acknowledgment lands. The relationship
+    is the invariant; the value itself is sized off the observed op-response
+    arrival distribution and moves with it.
+    """
+    assert OPERATION_RESPONSE_TIMEOUT > ACK_TIMEOUT
+
+
+def test_operation_incomplete_error_passes_the_retry_decorator() -> None:
+    """The type's whole purpose is to end the attempt ladder.
+
+    Its docstring says it is deliberately outside the bleak retry set, and
+    the consequence of losing that is a mechanical command re-sent after its
+    result went missing. Reparenting it under ResponseError would do exactly
+    that and leaves every other test in this file green.
+    """
+    assert not issubclass(OperationIncompleteError, RETRYABLE_EXCEPTIONS)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_op_response_timeout() -> None:
+    """Acknowledged but no op-response raises the non-retryable error."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=0.1,
+            progress=progress,
+        )
+    await feeder
+
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_stage_deadlines_run_from_the_command_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both stage timeouts subtract the time already spent in the attempt.
+
+    The acknowledgment wait asks for ACK_TIMEOUT minus the time the
+    write consumed, and the op-response wait asks for response_timeout minus
+    everything spent up to the acknowledgment, so the whole operation is
+    bounded from the moment the command is issued, exactly as
+    OperationIncompleteError's message states.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+
+    async def write_taking_half_a_second(*args: object, **kwargs: object) -> None:
+        clock["now"] += 0.5
+
+    client.write_gatt_char = AsyncMock(side_effect=write_taking_half_a_second)
+
+    ack_wait_timeouts: list[float | None] = []
+    real_wait = asyncio.wait
+
+    async def spying_wait(fs: object, **kwargs: object) -> object:
+        ack_wait_timeouts.append(kwargs.get("timeout"))  # type: ignore[arg-type]
+        return await real_wait(fs, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.wait", spying_wait)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        clock["now"] += 2.5  # the acknowledgment lands 3.0 s into the attempt
+        session._notify(0, bytearray(ack))
+        # The op-response must land in the op-response stage, so wait for that
+        # stage to arm its own bound rather than for progress.acknowledged,
+        # which is set as the frame is received and so is already true here.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=12.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    # The write consumed 0.5 s of the attempt, so the acknowledgment stage
+    # asked for the remainder of ACK_TIMEOUT, not the full budget again.
+    assert ack_wait_timeouts == [pytest.approx(ACK_TIMEOUT - 0.5)]
+    # The first bound is the write stage's own, ACK_TIMEOUT. The
+    # acknowledgment then spent 3.0 s of the 12.0 s response budget, so the
+    # op-response stage asked for the 9.0 s remainder.
+    assert op_wait_timeouts == [
+        pytest.approx(ACK_TIMEOUT),
+        pytest.approx(9.0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_response_matcher_skips_nonmatching_and_bad_frames() -> None:
+    """The plain execute path waits past a non-matching and a garbled frame."""
+    session, _ = _make_operation_session()
+    command = session.build_command(Commands.GETSTATUS)
+
+    def matcher(data: bytes) -> bool:
+        return len(data) > 1 and data[0] == 0xBB and data[1] == 0x02
+
+    nonmatching = _with_checksum(_OP_RESPONSE_OK)  # valid 0xBB 0x0B, wrong op
+    good = _with_checksum(_SETTLED_STATUS)  # valid 0xBB 0x02, matches
+    bad = _with_checksum(_SETTLED_STATUS)
+    bad[0x03] = (bad[0x03] + 1) & 0xFF  # corrupt the checksum
+
+    async def feed() -> None:
+        await _spin_until(lambda: session._notify_future is not None)
+        session._notify(0, bytearray(nonmatching))
+        await asyncio.sleep(0)
+        # A garbled frame during a plain wait DOES end it, matcher or no
+        # matcher: the wait is errored and _locked_write writes the command
+        # again. Only a staged operation wait skips corrupt frames.
+        session._notify(0, bytearray(bad))
+        await asyncio.sleep(0)
+        session._notify(0, bytearray(good))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute(command, "lock_status", matcher)
+    await feeder
+
+    assert result == bytes(good)
+    assert session.client.write_gatt_char.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cooldown_paces_a_command_behind_the_last_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the cooldown enabled, a command waits out the rest of COOLDOWN_TIME.
+
+    Both write paths share this wait. A command sent too soon after a frame
+    can stop the lock advertising, which needs a battery pull to recover, so
+    the session paces itself off the last frame it saw.
+    """
+    session, _ = _make_operation_session()
+    session.enable_cooldown()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    session._last_callback_time = clock["now"] - 0.2
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.sleep", fake_sleep)
+    await session._wait_for_cooldown()
+
+    assert slept == [pytest.approx(COOLDOWN_TIME - 0.2)]
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_pays_the_cooldown_before_its_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mechanical command waits out the cooldown before it is written.
+
+    A command written too soon after the lock's last frame can stop the lock
+    advertising, so the operation path pays the same wait as the settings
+    path rather than writing straight away.
+    """
+    session, client = _make_operation_session()
+    session.enable_cooldown()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    session._last_callback_time = clock["now"] - 0.2
+    slept: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        if delay:
+            slept.append(delay)
+            clock["now"] += delay
+        # The cooldown's own wait is the one under test; every other sleep in
+        # this test is a yield, so hand the loop a real one.
+        await real_sleep(0)
+
+    monkeypatch.setattr("yalexs_ble.session.asyncio.sleep", fake_sleep)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        session.build_operation_command(Commands.LOCK, 0x04),
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=OperationProgress(),
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert slept == [pytest.approx(COOLDOWN_TIME - 0.2)]
+
+
+# =========================================================================== #
+# Disconnect / auth contract of the operation wait
+#
+# The pre/post-acknowledgment retry hinge: a failure BEFORE the ack keeps its
+# retryable type (the command never moved the motor); once acknowledged the
+# result is unknown, so a disconnect or timeout becomes the non-retryable
+# OperationIncompleteError and the command is never silently re-sent. These
+# tests pin that contract so a future change that makes an acknowledged
+# operation retryable again fails the suite instead of shipping.
+# =========================================================================== #
+def _fire_disconnect(session: Session) -> None:
+    """Resolve the operation's disconnected future, as a link drop would.
+
+    execute_operation registers a future in _disconnected_futures and wraps the
+    wait in async_interrupt.interrupt(...); resolving that future raises
+    DisconnectedError inside the wait.
+    """
+    for fut in list(session._disconnected_futures):
+        if not fut.done():
+            fut.set_result(None)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_disconnect_after_ack_is_operation_incomplete() -> None:
+    """Disconnect AFTER the ack -> non-retryable OperationIncompleteError."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        _fire_disconnect(session)  # link drops while awaiting the op-response
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+
+@pytest.mark.asyncio
+async def test_ack_and_disconnect_in_one_turn_is_operation_incomplete() -> None:
+    """Ack and disconnect in ONE event-loop turn -> non-retryable.
+
+    The interrupt cancels the staged wait before it resumes, so nothing in the
+    wait body observes the acknowledgment. It still has to be recorded, or the
+    drop is classified as a pre-acknowledgment disconnect and the command is
+    re-sent to a lock that already took it.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # Both resolutions land in the same turn, with no await between them.
+        session._notify(0, bytearray(ack))
+        _fire_disconnect(session)
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(OperationIncompleteError):
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+    assert progress.acknowledged is True
+
+
+@pytest.mark.asyncio
+async def test_op_response_and_disconnect_in_one_turn_returns_the_result() -> None:
+    """Op-response and disconnect in ONE event-loop turn -> the result stands.
+
+    The twin of the acknowledgment race, with the opposite consequence: the
+    interrupt cancels the staged wait before it resumes, so the wait body never
+    sees the op-response it was given. Recorded where the frame arrives, the
+    result is in hand and a completed operation is reported as completed
+    instead of as one whose result never arrived.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # Both land in the same turn, with no await between them.
+        session._notify(0, bytearray(op_response))
+        _fire_disconnect(session)
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=5.0,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Op-response and stage-2 timeout in ONE event-loop turn -> the result stands.
+
+    The third twin, with the timer in the disconnect's role: the notify
+    delivering the op-response and the stage-2 timeout handle can become due
+    in the same event-loop iteration, and the timeout then cancels the wait
+    before it can resume with the result the future already holds. Recorded
+    where the frame arrives, the result is in hand and is returned instead of
+    raising OperationIncompleteError.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        # Wait for the op-response stage to arm its own timer, so the blocking
+        # sleep below expires that timer and not the acknowledgment stage's.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.05, session._notify, 0, bytearray(op_response))
+        # Block the loop past both deadlines: when it wakes, the notify handle
+        # (the earlier deadline) and the stage-2 timeout handle run in the
+        # same iteration, notify first, reproducing the race. The blocking
+        # sleep is the point, so the async lint rule is suppressed.
+        time.sleep(0.4)  # noqa: ASYNC251
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=0.2,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The op-response due after the stage-2 deadline still stands.
+
+    The twin of the ordering above: the two handles become due in one
+    event-loop iteration with the deadline the earlier of them, so the wait is
+    cancelled first and the frame lands on a wait that has not yet resumed.
+    Recorded where the frame arrives, the result is in hand either way round.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+    ack = _with_checksum(_ACK_SECUREMODE)
+    op_response = _with_checksum(_OP_RESPONSE_OK)
+
+    op_wait_timeouts: list[float] = []
+    real_asyncio_timeout = util.asyncio_timeout
+
+    def spying_asyncio_timeout(delay: float) -> object:
+        op_wait_timeouts.append(delay)
+        return real_asyncio_timeout(delay)
+
+    monkeypatch.setattr(
+        "yalexs_ble.session.util.asyncio_timeout", spying_asyncio_timeout
+    )
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        session._notify(0, bytearray(ack))
+        # Wait for the op-response stage to arm its own timer, so the blocking
+        # sleep below expires that timer and not the acknowledgment stage's.
+        await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.25, session._notify, 0, bytearray(op_response))
+        # Block the loop past both deadlines: when it wakes, the stage-2
+        # timeout handle (the earlier deadline) and the notify handle run in
+        # the same iteration, the timeout first, which is the ordering this
+        # test pins. The blocking sleep is the point, so the async lint rule
+        # is suppressed.
+        time.sleep(0.4)  # noqa: ASYNC251
+
+    feeder = asyncio.create_task(feed())
+    result = await session.execute_operation(
+        command,
+        "force_securemode",
+        ack_matcher=_ack_matcher(0x0B, 0x04),
+        response_matcher=_operation_response_matcher(0x0B),
+        response_timeout=0.2,
+        progress=progress,
+    )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_disconnect_before_ack_stays_retryable() -> None:
+    """Disconnect BEFORE the ack -> plain DisconnectedError (retryable)."""
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.LOCK, 0x04)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        _fire_disconnect(session)  # link drops before any acknowledgment
+
+    feeder = asyncio.create_task(feed())
+    with pytest.raises(DisconnectedError) as exc_info:
+        await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    await feeder
+
+    # Retryable: not the non-retryable type, and nothing was acknowledged.
+    assert not isinstance(exc_info.value, OperationIncompleteError)
+    assert progress.acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_key_error_on_write_raises_auth_error() -> None:
+    """A key/slot error on the first request surfaces as AuthError."""
+    session, client = _make_operation_session()
+    client.write_gatt_char = AsyncMock(side_effect=BleakError("Unlikely Error"))
+
+    with pytest.raises(AuthError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=OperationProgress(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_not_connected_raises_disconnected() -> None:
+    """The pre-write connected-guard raises, converted to DisconnectedError.
+
+    The one exit taken before the write call, so it is where write_attempted
+    stays False: a caller that must never re-send a command reads that
+    record, and every later exit has to report the command as possibly
+    delivered.
+    """
+    session, client = _make_operation_session()
+    client.is_connected = False
+    progress = OperationProgress()
+
+    with pytest.raises(DisconnectedError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert progress.write_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_errored_write_still_reports_the_write_as_attempted() -> None:
+    """An error raised by the write call leaves write_attempted True.
+
+    The request PDU can leave the radio with only the ATT response lost, so
+    an error from the write leaves delivery unknown, and write_attempted is
+    what carries that to the caller: set after the call instead, an errored
+    write would report False and read as a command that was never sent.
+    """
+    session, client = _make_operation_session()
+    client.write_gatt_char.side_effect = BleakError("write failed")
+    progress = OperationProgress()
+
+    with pytest.raises(BleakError, match="write failed"):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert progress.write_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_bleak_disconnect_after_ack_is_operation_incomplete() -> None:
+    """Defensive branch: a BleakError disconnect surfacing AFTER the ack is also
+    treated as an unknown result (OperationIncompleteError), not a retry."""
+    session, _ = _make_operation_session()
+    progress = OperationProgress()
+
+    def _boom(
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        progress.acknowledged = True
+        raise BleakError("device disconnected")
+
+    with (
+        patch.object(session, "_locked_write_operation", AsyncMock(side_effect=_boom)),
+        pytest.raises(OperationIncompleteError),
+    ):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+
+@pytest.mark.asyncio
+async def test_bleak_disconnect_in_one_turn_with_the_op_response_returns_it() -> None:
+    """The same twin on the BleakError arm: a recorded result still stands."""
+    session, _ = _make_operation_session()
+    progress = OperationProgress()
+    op_response = bytes(_with_checksum(_OP_RESPONSE_OK))
+
+    def _boom(
+        command: bytearray,
+        command_name: str,
+        ack_matcher: Callable[[bytes], bool],
+        response_matcher: Callable[[bytes], bool],
+        response_timeout: float,
+        progress: OperationProgress,
+        write_success_callback: Callable[[], None] | None = None,
+    ) -> bytes:
+        progress.acknowledged = True
+        progress.result = op_response
+        raise BleakError("device disconnected")
+
+    with patch.object(session, "_locked_write_operation", AsyncMock(side_effect=_boom)):
+        result = await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
+
+    assert result == op_response
+
+
+@pytest.mark.asyncio
+async def test_execute_settings_not_connected_raises_disconnected() -> None:
+    """The settings/poll path's pre-write connected-guard also raises."""
+    session, client = _make_operation_session()
+    client.is_connected = False
+
+    with pytest.raises(DisconnectedError):
+        await session.execute(session.build_command(Commands.GETSTATUS), "status")
+
+
+@pytest.mark.asyncio
+async def test_notify_returns_when_only_ack_is_armed_and_frame_does_not_match() -> None:
+    """A frame the acknowledgment matcher refuses resolves nothing.
+
+    The operation record and the acknowledgment wait are both armed, so the
+    matcher is consulted, and with no result wait behind it the frame is
+    dropped once the state callback has seen it.
+    """
+    session, _ = _make_operation_session()
+    # The record is what admits a frame to the acknowledgment branch at all;
+    # without it the matcher below is never reached.
+    session._operation_progress = OperationProgress()
+    session._ack_future = asyncio.get_running_loop().create_future()
+    matcher = _ack_matcher(0x0B, 0x04)
+    offered: list[bytes] = []
+
+    def counting_matcher(data: bytes) -> bool:
+        offered.append(data)
+        return matcher(data)
+
+    session._ack_matcher = counting_matcher
+    session._notify_future = None
+    session._notify_matcher = None
+
+    # A settled GETSTATUS (0xBB) never matches the 0xAA ack matcher.
+    frame = _with_checksum(_SETTLED_STATUS)
+    session._notify(0, bytearray(frame))
+
+    assert offered == [bytes(frame)]
+    assert not session._ack_future.done()
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_generic_bleak_error_is_reraised() -> None:
+    """A BleakError that is neither a key nor a disconnect error re-raises as-is.
+
+    It stays a plain (retryable) BleakError, not converted to AuthError or
+    DisconnectedError, so the write may simply be retried.
+    """
+    session, client = _make_operation_session()
+    client.write_gatt_char = AsyncMock(side_effect=BleakError("GATT write failed"))
+
+    with pytest.raises(BleakError):
+        await session.execute_operation(
+            session.build_operation_command(Commands.LOCK, 0x04),
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=OperationProgress(),
+        )
+
+
+# =========================================================================== #
+# 1000 ms field replays: the typed staged wait vs the wrong-capture frames
+#
+# Verbatim, ordered field frame sequences from fixtures_1000ms_wrong_captures.md
+# where the OLD untyped wait captured a wrong frame, written ahead of the staged
+# wait that answers them. Each is replayed through session._notify during an
+# execute_operation staged wait. Frame classes:
+#   * bb0a / bb0b = 0xBB op-response (opcode 0x0a unlock / 0x0b lock+securemode)
+#   * bb02        = 0xBB 0x02 settled GETSTATUS status push
+#   * aa0a / aa0b = 0xAA acknowledgment matching the written opcode
+# byte[3] checksums are valid as captured, so the frames are fed unchanged.
+# =========================================================================== #
+@pytest.mark.asyncio
+async def test_replay_incident1_force_lock_ignores_prev_unlock_stale_bb0a() -> None:
+    """Incident 1: a force_lock wait ignores the previous unlock's stale bb0a.
+
+    The old untyped wait was satisfied by bb0a003b..., the delayed op-response
+    (opcode 0x0a = unlock) of the PRECEDING force_unlock, a leftover frame, not
+    an answer to this force_lock (opcode 0x0b). The typed wait keeps it on the
+    state-callback path and completes only on this force_lock's own bb0b.
+    """
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_command(Commands.LOCK)  # force_lock: opcode 0x0b
+
+    # Verbatim field frames (byte[3] checksums valid as captured).
+    stale_unlock_result = bytes.fromhex("bb0a003b0000000000000000000000000000")
+    settled_unlocked = bytes.fromhex("bb02003e0200000003000000000000000000")
+    true_lock_ack = bytes.fromhex("aa0b00490000000000000000000000000200")
+    genuine_lock_result = bytes.fromhex("bb0b003a0000000000000000000000000000")
+
+    op_task: asyncio.Task[bytes] | None = None
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # The previous unlock's stale op-response and a settled status push:
+        # neither is this force_lock's ack or op-response.
+        session._notify(0, bytearray(stale_unlock_result))
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert op_task is not None and not op_task.done()  # wrong frame ignored
+        # The genuine LOCK ack (opcode 0x0b, op byte 0x00) advances to stage 2.
+        session._notify(0, bytearray(true_lock_ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # Only its own bb0b op-response completes the wait.
+        session._notify(0, bytearray(genuine_lock_result))
+
+    feeder = asyncio.create_task(feed())
+    op_task = asyncio.create_task(
+        session.execute_operation(
+            command,
+            "force_lock",
+            ack_matcher=_ack_matcher(Commands.LOCK, 0x00),
+            response_matcher=_operation_response_matcher(Commands.LOCK),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    )
+    result = await op_task
+    await feeder
+
+    assert result == genuine_lock_result
+    # It went through the real ack stage; the stale bb0a did not short-circuit.
+    assert progress.acknowledged is True
+    # The stale op-response and the settle stayed on the state-callback path.
+    assert stale_unlock_result in seen
+    assert settled_unlocked in seen
+
+
+@pytest.mark.asyncio
+async def test_a_settled_status_push_completes_neither_operation_stage() -> None:
+    """A settled status push answers neither stage of an unlock's staged wait.
+
+    A GETSTATUS status push (0xBB 0x02) is not an operation frame, so it
+    answers neither the acknowledgment stage nor the op-response stage. Only
+    the unlock's own bb0a completes the wait.
+    """
+    seen: list[bytes] = []
+    session, client = _make_operation_session(seen.append)
+    progress = OperationProgress()
+    command = session.build_command(Commands.UNLOCK)  # force_unlock: opcode 0x0a
+
+    # Verbatim field frames (byte[3] checksums valid as captured).
+    settled_unlocked = bytes.fromhex("bb02003e0200000003000000000000000000")
+    true_unlock_ack = bytes.fromhex("aa0a004a0000000000000000000000000200")
+    genuine_unlock_result = bytes.fromhex("bb0a003b0000000000000000000000000000")
+
+    op_task: asyncio.Task[bytes] | None = None
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # A settled status push during the ack stage does not complete it.
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert op_task is not None and not op_task.done()
+        session._notify(0, bytearray(true_unlock_ack))
+        await _spin_until(lambda: progress.acknowledged)
+        # A settled status push during the op-response stage does not either.
+        session._notify(0, bytearray(settled_unlocked))
+        await asyncio.sleep(0)
+        assert not op_task.done()
+        session._notify(0, bytearray(genuine_unlock_result))
+
+    feeder = asyncio.create_task(feed())
+    op_task = asyncio.create_task(
+        session.execute_operation(
+            command,
+            "force_unlock",
+            ack_matcher=_ack_matcher(Commands.UNLOCK, 0x00),
+            response_matcher=_operation_response_matcher(Commands.UNLOCK),
+            response_timeout=5.0,
+            progress=progress,
+        )
+    )
+    result = await op_task
+    await feeder
+
+    assert result == genuine_unlock_result
+    assert progress.acknowledged is True
+    # Both settled pushes stayed on the state-callback path, never claimed.
+    assert seen.count(settled_unlocked) == 2

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -621,6 +621,7 @@ def _make_operation_session(
 # securemode = LOCK opcode (0x0B) with operation byte 0x04.
 _ACK_SECUREMODE = "aa0b00000400000000000000000000000200"
 _OP_RESPONSE_OK = "bb0b00000000000000000000000000000200"
+_OP_RESPONSE_UNLOCK_OK = "bb0a00000000000000000000000000000200"
 _SETTLED_STATUS = "bb0200000200000000000000000000000200"
 _FOREIGN_ACK = "aa0b00000000000000000000000000000200"
 
@@ -1513,6 +1514,47 @@ async def test_op_response_and_disconnect_in_one_turn_returns_the_result() -> No
 
     assert result == bytes(op_response)
     assert progress.result == bytes(op_response)
+
+
+@pytest.mark.asyncio
+async def test_a_result_recovered_at_a_disconnect_still_logs_a_missing_acknowledgment(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The disconnect-race return is a completion, so it logs like the others.
+
+    An operation that skips the acknowledgment wait, the unlatch's shape, has
+    its op-response and a link drop land in one turn with nothing
+    acknowledged. The recorded result is returned, and the completion with
+    no acknowledgment is logged, the line every completion path carries.
+    """
+    session, client = _make_operation_session()
+    progress = OperationProgress()
+    command = session.build_operation_command(Commands.UNLOCK, 0x0A)
+    op_response = _with_checksum(_OP_RESPONSE_UNLOCK_OK)
+
+    async def feed() -> None:
+        await _spin_until_written(client)
+        # Both land in the same turn, with no await between them, the drop
+        # delivered first, and no acknowledgment ever arrives.
+        _fire_disconnect(session)
+        session._notify(0, bytearray(op_response))
+
+    feeder = asyncio.create_task(feed())
+    with caplog.at_level("INFO", logger="yalexs_ble.session"):
+        result = await session.execute_operation(
+            command,
+            "force_unlatch",
+            ack_matcher=_ack_matcher(0x0A, 0x0A),
+            response_matcher=_operation_response_matcher(0x0A),
+            response_timeout=5.0,
+            progress=progress,
+            wait_for_ack=False,
+        )
+    await feeder
+
+    assert result == bytes(op_response)
+    assert progress.acknowledged is False
+    assert "completed on its op-response; no acknowledgment was received" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1106,7 +1106,7 @@ async def test_stage_deadlines_run_from_the_command_issue(
     op_response = _with_checksum(_OP_RESPONSE_OK)
 
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
 
     async def write_taking_half_a_second(*args: object, **kwargs: object) -> None:
         clock["now"] += 0.5
@@ -1213,7 +1213,7 @@ async def test_cooldown_paces_a_command_behind_the_last_frame(
     session, _ = _make_operation_session()
     session.enable_cooldown()
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
     session._last_callback_time = clock["now"] - 0.2
     slept: list[float] = []
 
@@ -1240,7 +1240,7 @@ async def test_execute_operation_pays_the_cooldown_before_its_write(
     session, client = _make_operation_session()
     session.enable_cooldown()
     clock = {"now": 1000.0}
-    monkeypatch.setattr("yalexs_ble.session.time.monotonic", lambda: clock["now"])
+    monkeypatch.setattr("yalexs_ble.session.monotonic", lambda: clock["now"])
     session._last_callback_time = clock["now"] - 0.2
     slept: list[float] = []
     real_sleep = asyncio.sleep
@@ -1434,13 +1434,16 @@ async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
         # Wait for the op-response stage to arm its own timer, so the blocking
         # sleep below expires that timer and not the acknowledgment stage's.
         await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        # Key the schedule to the armed stage-2 budget, so the ordering
+        # holds however long the run spent getting here.
+        armed = op_wait_timeouts[1]
         loop = asyncio.get_running_loop()
-        loop.call_later(0.05, session._notify, 0, bytearray(op_response))
+        loop.call_later(armed / 4, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the notify handle
         # (the earlier deadline) and the stage-2 timeout handle run in the
         # same iteration, notify first, reproducing the race. The blocking
         # sleep is the point, so the async lint rule is suppressed.
-        time.sleep(0.4)  # noqa: ASYNC251
+        time.sleep(armed + 0.1)  # noqa: ASYNC251
 
     feeder = asyncio.create_task(feed())
     result = await session.execute_operation(
@@ -1491,14 +1494,17 @@ async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
         # Wait for the op-response stage to arm its own timer, so the blocking
         # sleep below expires that timer and not the acknowledgment stage's.
         await _spin_until(lambda: len(op_wait_timeouts) == 2)
+        # Key the schedule to the armed stage-2 budget, so the ordering
+        # holds however long the run spent getting here.
+        armed = op_wait_timeouts[1]
         loop = asyncio.get_running_loop()
-        loop.call_later(0.25, session._notify, 0, bytearray(op_response))
+        loop.call_later(armed + 0.05, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the stage-2
         # timeout handle (the earlier deadline) and the notify handle run in
         # the same iteration, the timeout first, which is the ordering this
         # test pins. The blocking sleep is the point, so the async lint rule
         # is suppressed.
-        time.sleep(0.4)  # noqa: ASYNC251
+        time.sleep(armed + 0.15)  # noqa: ASYNC251
 
     feeder = asyncio.create_task(feed())
     result = await session.execute_operation(
@@ -1744,10 +1750,10 @@ async def test_execute_operation_generic_bleak_error_is_reraised() -> None:
 # =========================================================================== #
 # 1000 ms field replays: the typed staged wait vs the wrong-capture frames
 #
-# Verbatim, ordered field frame sequences from fixtures_1000ms_wrong_captures.md
-# where the OLD untyped wait captured a wrong frame, written ahead of the staged
-# wait that answers them. Each is replayed through session._notify during an
-# execute_operation staged wait. Frame classes:
+# Verbatim, ordered field frame sequences in which the OLD untyped wait
+# captured a wrong frame, written ahead of the staged wait that answers them.
+# Each is replayed through session._notify during an execute_operation staged
+# wait. Frame classes:
 #   * bb0a / bb0b = 0xBB op-response (opcode 0x0a unlock / 0x0b lock+securemode)
 #   * bb02        = 0xBB 0x02 settled GETSTATUS status push
 #   * aa0a / aa0b = 0xAA acknowledgment matching the written opcode

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1442,6 +1442,9 @@ async def test_op_response_and_stage_two_timeout_in_one_turn_returns_the_result(
         # Key the schedule to the armed stage-2 budget, so the ordering
         # holds however long the run spent getting here.
         armed = op_wait_timeouts[1]
+        # armed == 0 would put the notify and the timeout on one deadline,
+        # decided by scheduling order; a stalled run must fail as stalled.
+        assert armed > 0, "the fixture stalled past the stage-2 budget"
         loop = asyncio.get_running_loop()
         loop.call_later(armed / 4, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the notify handle
@@ -1502,6 +1505,9 @@ async def test_an_op_response_behind_the_stage_two_timeout_returns_the_result(
         # Key the schedule to the armed stage-2 budget, so the ordering
         # holds however long the run spent getting here.
         armed = op_wait_timeouts[1]
+        # armed == 0 would put the notify and the timeout on one deadline,
+        # decided by scheduling order; a stalled run must fail as stalled.
+        assert armed > 0, "the fixture stalled past the stage-2 budget"
         loop = asyncio.get_running_loop()
         loop.call_later(armed + 0.05, session._notify, 0, bytearray(op_response))
         # Block the loop past both deadlines: when it wakes, the stage-2

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -963,14 +963,17 @@ async def test_execute_operation_op_response_before_ack() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
+async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """A previous same-opcode command's late op-response is taken as the answer.
 
     An op-response is matched on the opcode alone, so a fresh wait cannot
     tell its own answer from the previous same-opcode command's late one:
     fed during stage 1, the stale frame completes the wait through the
     supersede branch. progress.acknowledged staying False is the tell that
-    the result may not be this command's.
+    the result may not be this command's, and the completion is logged at
+    info so the case is visible in a field log.
     """
     session, client = _make_operation_session()
     progress = OperationProgress()
@@ -984,18 +987,20 @@ async def test_a_stale_same_opcode_op_response_completes_a_fresh_wait() -> None:
         session._notify(0, bytearray(stale_op_response))
 
     feeder = asyncio.create_task(feed())
-    result = await session.execute_operation(
-        command,
-        "force_securemode",
-        ack_matcher=_ack_matcher(0x0B, 0x04),
-        response_matcher=_operation_response_matcher(0x0B),
-        response_timeout=5.0,
-        progress=progress,
-    )
+    with caplog.at_level("INFO", logger="yalexs_ble.session"):
+        result = await session.execute_operation(
+            command,
+            "force_securemode",
+            ack_matcher=_ack_matcher(0x0B, 0x04),
+            response_matcher=_operation_response_matcher(0x0B),
+            response_timeout=5.0,
+            progress=progress,
+        )
     await feeder
 
     assert result == bytes(stale_op_response)
     assert progress.acknowledged is False
+    assert "completed on its op-response; no acknowledgment was received" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -31,6 +31,7 @@ from yalexs_ble.session import (
     OperationProgress,
     ResponseError,
     Session,
+    UnlatchError,
 )
 
 # Verbatim field frames (2026-07-16 capture, YUR/DEL fw 2.1.0): the READSETTING
@@ -1144,9 +1145,11 @@ def test_operation_response_timeout_outlasts_the_acknowledgment_budget(
     budget at or below ACK_TIMEOUT could reach stage 2 with nothing left and
     fail the operation the moment the acknowledgment lands. The unlatch
     skips the acknowledgment stage, but ACK_TIMEOUT still bounds its GATT
-    write, so the same floor holds. The relationship is the invariant; the
-    plain budget is sized off the observed op-response arrival distribution
-    and moves with it, and the unlatch budget derives from its latch travel.
+    write, so the same floor holds. The floor is asserted once per budget
+    constant rather than once per distinct value: the plain budget is sized
+    off the observed op-response arrival distribution and the unlatch budget
+    is the latch pull's own tuning point, so the two names carry one value
+    today and either may be moved on its own.
     """
     assert budget > ACK_TIMEOUT
 
@@ -1160,6 +1163,18 @@ def test_operation_incomplete_error_passes_the_retry_decorator() -> None:
     that and leaves every other test in this file green.
     """
     assert not issubclass(OperationIncompleteError, RETRYABLE_EXCEPTIONS)
+
+
+def test_unlatch_error_passes_the_retry_decorator() -> None:
+    """A repeated unlatch opens the door again, so the type must not retry.
+
+    force_unlatch converts every post-write failure to this type, and the
+    conversion only stops the re-send while the type stays outside the retry
+    set. The set is assembled from bleak_retry_connector, so reparenting
+    UnlatchError under BleakError or ResponseError would put it back in and
+    leaves every other test in this file green.
+    """
+    assert not issubclass(UnlatchError, RETRYABLE_EXCEPTIONS)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Locks with a retractable latch can open the door, not just unlock it: the Unlock opcode with operation byte 0x0A.

An unlatch is a cycle: the latch is pulled, held retracted for the lock's hold time, and springs back. The operation completes at UNLATCHED with an op-response with the latch pulled, the door lock open, and with the cycle still running. The unlatch now has its own response budget so it can be tuned on its own. The UNLATCHED hold time, finishing after the op-response, is a user setting in the vendor app with a range of 3 to 30 seconds, and the latch then returns to its resting state. For an always-connected lock the settled position arrives on the lock's own status push or the next poll. UNLATCHED counts as a position the lock holds, ended by the lock's own timer as UNLOCKED may be ended by auto-lock, so the follow-up poll after an unlatch waits the keep-alive as after a lock or unlock, and an applied UNLATCHED marks the status seen as any other position does. For a lock connected on demand either the state change advertisement triggers a lock poll, or the end-user changes the lock connection to always-connected if that functionality is required.

A reported UNLATCHING and UNLATCHED now reach the display; mapping them to Home Assistant's opening and open lock states is integration work to follow.

A repeated unlatch opens the door again, so once the command write has been attempted no failure may re-send it. Every failure from that point converts to UnlatchError, a YaleXSBLEError the retry decorator does not retry (OperationIncompleteError, already non-retryable, propagates as itself), and the display reports the position as unknown, since the latch may have fired. For the same reason the operation waits on its op-response alone: Session.execute_operation takes wait_for_ack for it, and an early delivery signal is useless to a caller that must never re-send. An operation can now time out unacknowledged, so the OperationIncompleteError message reports when the command was never acknowledged.

The unlatch reuses the existing transitional pair rather than adding one: the projection already maps a reported UNLATCHING onto UNLOCKING when the lock was secured and UNLOCKED otherwise, so the secure channel's published alphabet is unchanged. OperationProgress.write_attempted, written since the staged wait and unread until now, gets its consumer here: force_unlatch owns the record and reads it to decide whether a failure may be re-sent. Skipping the acknowledgment wait costs the unlatch its fast fail on a dead link, by design: a command that never reached the lock fails at the full budget with a non-retryable type, and the follow-up status poll covers the recovery. The op-response result byte is still not raised to the caller; the next part converts a reported failure to OperationFailedError.

No capability needs to gate the command as it does not change the library's behaviour and the decision to use it is the caller's responsibility.

Testing: `test_unlatch_stamps_unlatching_then_unlatched` pins UNLATCHED as the operation's own outcome, and `test_the_resting_state_replaces_unlatched_when_it_arrives` observes the settle at UNLOCKED and at LOCKED. `test_force_unlatch_converts_every_post_write_failure` pins the conversion on three types the retry set carries and one outside every retry set, and `test_unlatch_error_passes_the_retry_decorator` pins UnlatchError itself outside that set, which is what stops the re-send. `test_an_unlatch_completes_without_an_acknowledgment` pins the op-response-alone wait, and `test_force_unlatch_passes_its_own_op_response_budget` pins the budget wiring against a patched distinct value. `test_unlatching_a_secured_lock_animates_then_releases_the_secure_lock` pins the secure channel through an unlatch of a secured lock. The rest covers the display exits.

Corrects the first version of this PR which assumed that op-response was issued after the unlatch hold time.
Command and lock response shape and timings verified by logs supplied by @rgnyld2.

Subsumes #351.

This branch is stacked on #388. The fifth of eight parts implementing #369.

